### PR TITLE
Correct the publish time zone of the Portolan cross-post

### DIFF
--- a/content/blog/2026/260902-introducing-portolan.md
+++ b/content/blog/2026/260902-introducing-portolan.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-09-02T10:00:00-04:00"
+date: "2026-09-02T10:00:00+02:00"
 slug: introducing-portolan
 title: "Introducing Portolan: A serverless spatial data infrastructure"
 tags: []


### PR DESCRIPTION
The Portolan cross-post does not appear on the blog. This change makes it appear on the next build.

## What changed

The date offset in `content/blog/2026/260902-introducing-portolan.md` changes from `-04:00` to `+02:00`.

```
-date: "2026-09-02T10:00:00-04:00"
+date: "2026-09-02T10:00:00+02:00"
```

## Why

The post publishes at 10:00 CET. The frontmatter carried 10:00 ET, which is 6 hours later.

Hugo omits content with a future date. The Vercel build command is `hugo --gc --minify`, and it does not pass `--buildFuture`. `hugo.toml` does not set `buildFuture` either. The build after the merge of #149 read a future date and left the post out.

## Verification

The live URL returns 404 before this change:

```
$ curl -s -o /dev/null -w "%{http_code}\n" \
    https://cloudnativegeo.org/blog/2026/09/introducing-portolan/
404
```

The blog index does not list the post:

```
$ curl -s https://cloudnativegeo.org/blog/ | grep -c -i portolan
0
```

The corrected date is in the past, so the next build includes the post:

```
$ python3 -c "
import datetime
d = datetime.datetime.fromisoformat(\"2026-09-02T10:00:00+02:00\")
now = datetime.datetime.now(datetime.timezone.utc)
print(\"post date UTC:\", d.astimezone(datetime.timezone.utc))
print(\"now UTC      :\", now)
print(\"PAST (will build):\", d < now)
"
post date UTC: 2026-09-02 08:00:00+00:00
now UTC      : 2026-09-02 08:20:13.107882+00:00
PAST (will build): True
```