### PR TITLE
Update CNG Forum and NYC/series sponsorship prospectus PDFs

### DIFF
--- a/static/cng-2026-series-sponsor.pdf
+++ b/static/cng-2026-series-sponsor.pdf
@@ -2,2542 +2,779 @@
 %€€€€
 
 1 0 obj
-<<
-  /Type /Pages
-  /Count 5
-  /Kids [162 0 R 164 0 R 166 0 R 169 0 R 172 0 R]
->>
+<</Type/Pages/Count 3/Kids[138 0 R 139 0 R 140 0 R]>>
 endobj
-
 2 0 obj
-<<
-  /Type /Outlines
-  /First 3 0 R
-  /Last 3 0 R
-  /Count 1
->>
+<</Parent 11 0 R/Next 3 0 R/Title(About Cloud-Native Geospatial Forum (CNG))/Dest 116 0 R>>
 endobj
-
 3 0 obj
-<<
-  /Parent 2 0 R
-  /First 4 0 R
-  /Last 12 0 R
-  /Count -7
-  /Title (CNG 2026 Community Partner Program)
-  /Dest 161 0 R
->>
+<</Parent 11 0 R/Next 8 0 R/Prev 2 0 R/Title(About CNG NYC)/Dest 117 0 R>>
 endobj
-
 4 0 obj
-<<
-  /Parent 3 0 R
-  /Next 5 0 R
-  /Title (About Cloud-Native Geospatial Forum (CNG))
-  /Dest 152 0 R
->>
+<</Parent 8 0 R/Next 5 0 R/Title(CNG NYC Reception host: $5,000)/Dest 118 0 R>>
 endobj
-
 5 0 obj
-<<
-  /Parent 3 0 R
-  /Next 6 0 R
-  /Prev 4 0 R
-  /Title (The 2026 CNG event series)
-  /Dest 153 0 R
->>
+<</Parent 8 0 R/Next 6 0 R/Prev 4 0 R/Title(CNG NYC Event sponsor: $2,000)/Dest 119 0 R>>
 endobj
-
 6 0 obj
-<<
-  /Parent 3 0 R
-  /Next 7 0 R
-  /Prev 5 0 R
-  /Title <FEFF0043006F006D006D0075006E00690074007900200050006100720074006E0065007200202014002000240035002C003000300030>
-  /Dest 154 0 R
->>
+<</Parent 8 0 R/Next 7 0 R/Prev 5 0 R/Title(CNG 2026 community partner: $5,000)/Dest 120 0 R>>
 endobj
-
 7 0 obj
-<<
-  /Parent 3 0 R
-  /Next 10 0 R
-  /Prev 6 0 R
-  /First 8 0 R
-  /Last 9 0 R
-  /Count -2
-  /Title (Bundle with CNG Membership)
-  /Dest 157 0 R
->>
+<</Parent 8 0 R/Prev 6 0 R/Title(CNG membership renewal + community partner: $8,000)/Dest 121 0 R>>
 endobj
-
 8 0 obj
-<<
-  /Parent 7 0 R
-  /Next 9 0 R
-  /Title (For new CNG Commercial Members)
-  /Dest 155 0 R
->>
+<</Parent 11 0 R/Next 9 0 R/Prev 3 0 R/First 4 0 R/Last 7 0 R/Count -4/Title(Sponsorship Opportunities)/Dest 122 0 R>>
 endobj
-
 9 0 obj
-<<
-  /Parent 7 0 R
-  /Prev 8 0 R
-  /Title (For renewing CNG Commercial Members)
-  /Dest 156 0 R
->>
+<</Parent 11 0 R/Next 10 0 R/Prev 8 0 R/Title(Why sponsor CNG NYC?)/Dest 123 0 R>>
 endobj
-
 10 0 obj
-<<
-  /Parent 3 0 R
-  /Next 11 0 R
-  /Prev 7 0 R
-  /Title (Why partner with CNG)
-  /Dest 158 0 R
->>
+<</Parent 11 0 R/Prev 9 0 R/Title(Get in touch)/Dest 124 0 R>>
 endobj
-
 11 0 obj
-<<
-  /Parent 3 0 R
-  /Next 12 0 R
-  /Prev 10 0 R
-  /Title (Event-specific sponsorships)
-  /Dest 159 0 R
->>
+<</Parent 12 0 R/First 2 0 R/Last 10 0 R/Count -5/Title(CNG NYC 2026 sponsorship prospectus)/Dest 125 0 R>>
 endobj
-
 12 0 obj
-<<
-  /Parent 3 0 R
-  /Prev 11 0 R
-  /Title (Get in touch)
-  /Dest 160 0 R
->>
+<</Type/Outlines/First 11 0 R/Last 11 0 R/Count 1>>
 endobj
-
 13 0 obj
-<<
-  /Type /StructTreeRoot
-  /RoleMap <<
-    /Datetime /Span
-    /Terms /Part
-    /Title /P
-    /Strong /Span
-    /Em /Span
-  >>
-  /K [19 0 R]
-  /ParentTree <<
-    /Nums [0 14 0 R 1 15 0 R 2 16 0 R 3 41 0 R 4 17 0 R 5 25 0 R 6 18 0 R]
-  >>
-  /ParentTreeNextKey 7
->>
+<</Type/StructTreeRoot/RoleMap<</Datetime/Span/Terms/Part/Title/P/Strong/Span/Em/Span>>/K[112 0 R]/ParentTree<</Nums[0 24 0 R 1 14 0 R 2 15 0 R 3 106 0 R 4 16 0 R]>>/ParentTreeNextKey 5>>
 endobj
-
 14 0 obj
-[131 0 R 130 0 R 130 0 R 129 0 R 127 0 R 127 0 R 127 0 R 127 0 R]
+[17 0 R 21 0 R 22 0 R 23 0 R 26 0 R 27 0 R 27 0 R 27 0 R 28 0 R 29 0 R 29 0 R 29 0 R 29 0 R 29 0 R 30 0 R 30 0 R 30 0 R 31 0 R 31 0 R]
 endobj
-
 15 0 obj
-[126 0 R 125 0 R 125 0 R 125 0 R 125 0 R 124 0 R 123 0 R 123 0 R 123 0 R 123 0 R 122 0 R 121 0 R 120 0 R 118 0 R 117 0 R 116 0 R 114 0 R 113 0 R 112 0 R 110 0 R 109 0 R 109 0 R 108 0 R 106 0 R 105 0 R 104 0 R 102 0 R 101 0 R 100 0 R 97 0 R 96 0 R 96 0 R 95 0 R 95 0 R]
+[32 0 R 33 0 R 34 0 R 36 0 R 36 0 R 37 0 R 38 0 R 38 0 R 40 0 R 41 0 R 43 0 R 44 0 R 46 0 R 47 0 R 49 0 R 50 0 R 52 0 R 53 0 R 56 0 R 57 0 R 59 0 R 60 0 R 62 0 R 63 0 R 65 0 R 66 0 R 68 0 R 69 0 R 72 0 R 73 0 R 73 0 R 73 0 R 73 0 R 74 0 R 75 0 R 77 0 R 78 0 R 80 0 R 81 0 R 81 0 R 83 0 R 84 0 R 86 0 R 87 0 R]
 endobj
-
 16 0 obj
-[95 0 R 95 0 R 94 0 R 92 0 R 91 0 R 91 0 R 89 0 R 88 0 R 86 0 R 85 0 R 83 0 R 82 0 R 82 0 R 80 0 R 79 0 R 76 0 R 76 0 R 76 0 R 76 0 R 75 0 R 74 0 R 74 0 R 73 0 R 72 0 R 71 0 R 69 0 R 68 0 R 66 0 R 65 0 R 63 0 R 61 0 R]
+[90 0 R 90 0 R 91 0 R 92 0 R 92 0 R 93 0 R 94 0 R 96 0 R 97 0 R 100 0 R 101 0 R 101 0 R 101 0 R 101 0 R 101 0 R 102 0 R 102 0 R 102 0 R 102 0 R 103 0 R 104 0 R 105 0 R 107 0 R 106 0 R 108 0 R 110 0 R 110 0 R]
 endobj
-
 17 0 obj
-[57 0 R 56 0 R 55 0 R 53 0 R 52 0 R 50 0 R 49 0 R 47 0 R 45 0 R 40 0 R 40 0 R 40 0 R 41 0 R 40 0 R 40 0 R 39 0 R 38 0 R 37 0 R 37 0 R 37 0 R 37 0 R 36 0 R 35 0 R 35 0 R 35 0 R 35 0 R 34 0 R 33 0 R 33 0 R 33 0 R 32 0 R 31 0 R 31 0 R 31 0 R]
+<</Type/StructElem/S/Figure/P 18 0 R/A[<</O/Layout/Placement/Block>>]/K[0]/Pg 138 0 R>>
 endobj
-
 18 0 obj
-[30 0 R 29 0 R 29 0 R 29 0 R 29 0 R 29 0 R 28 0 R 27 0 R 27 0 R 26 0 R 24 0 R 25 0 R 23 0 R 21 0 R 21 0 R 21 0 R]
+<</Type/StructElem/S/Div/P 20 0 R/K[17 0 R]>>
 endobj
-
 19 0 obj
-<<
-  /Type /StructElem
-  /S /Document
-  /P 13 0 R
-  /K [131 0 R 130 0 R 128 0 R 127 0 R 126 0 R 125 0 R 124 0 R 123 0 R 98 0 R 97 0 R 96 0 R 95 0 R 93 0 R 77 0 R 76 0 R 75 0 R 74 0 R 73 0 R 58 0 R 57 0 R 42 0 R 40 0 R 39 0 R 37 0 R 35 0 R 33 0 R 31 0 R 30 0 R 29 0 R 28 0 R 27 0 R 24 0 R 22 0 R 20 0 R]
->>
+<</Type/StructElem/S/Div/P 20 0 R/K[]>>
 endobj
-
 20 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [21 0 R]
->>
+<</Type/StructElem/S/Div/P 112 0 R/K[18 0 R 19 0 R]>>
 endobj
-
 21 0 obj
-<<
-  /Type /StructElem
-  /S /Em
-  /P 20 0 R
-  /K [13 14 15]
-  /Pg 172 0 R
->>
+<</Type/StructElem/S/H1/P 112 0 R/T(CNG NYC 2026 sponsorship prospectus)/K[1]/Pg 138 0 R>>
 endobj
-
 22 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [23 0 R]
->>
+<</Type/StructElem/S/Strong/P 25 0 R/K[2]/Pg 138 0 R>>
 endobj
-
 23 0 obj
-<<
-  /Type /StructElem
-  /S /Em
-  /P 22 0 R
-  /K [12]
-  /Pg 172 0 R
->>
+<</Type/StructElem/S/Strong/P 24 0 R/K[3]/Pg 138 0 R>>
 endobj
-
 24 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [26 0 R 10 25 0 R]
-  /Pg 172 0 R
->>
+<</Type/StructElem/S/Link/P 25 0 R/K[23 0 R<</Type/OBJR/Pg 138 0 R/Obj 113 0 R>>]>>
 endobj
-
 25 0 obj
-<<
-  /Type /StructElem
-  /S /Link
-  /P 24 0 R
-  /K [11 <<
-    /Type /OBJR
-    /Pg 172 0 R
-    /Obj 171 0 R
-  >>]
-  /Pg 172 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[22 0 R 24 0 R]>>
 endobj
-
 26 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 24 0 R
-  /K [9]
-  /Pg 172 0 R
->>
+<</Type/StructElem/S/H2/P 112 0 R/T(About Cloud-Native Geospatial Forum (CNG))/K[4]/Pg 138 0 R>>
 endobj
-
 27 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [7 8]
-  /Pg 172 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[5 6 7]/Pg 138 0 R>>
 endobj
-
 28 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 19 0 R
-  /T (Get in touch)
-  /K [6]
-  /Pg 172 0 R
->>
+<</Type/StructElem/S/H2/P 112 0 R/T(About CNG NYC)/K[8]/Pg 138 0 R>>
 endobj
-
 29 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [1 2 3 4 5]
-  /Pg 172 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[9 10 11 12 13]/Pg 138 0 R>>
 endobj
-
 30 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 19 0 R
-  /T (Event-specific sponsorships)
-  /K [0]
-  /Pg 172 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[14 15 16]/Pg 138 0 R>>
 endobj
-
 31 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [32 0 R 31 32 33]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[17 18]/Pg 138 0 R>>
 endobj
-
 32 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 31 0 R
-  /K [30]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/H2/P 112 0 R/T(Sponsorship Opportunities)/K[0]/Pg 139 0 R>>
 endobj
-
 33 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [34 0 R 27 28 29]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/H3/P 112 0 R/T(CNG NYC Reception host: $5,000)/K[1]/Pg 139 0 R>>
 endobj
-
 34 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 33 0 R
-  /K [26]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/Em/P 35 0 R/K[2]/Pg 139 0 R>>
 endobj
-
 35 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [36 0 R 22 23 24 25]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[34 0 R]>>
 endobj
-
 36 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 35 0 R
-  /K [21]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[3 4]/Pg 139 0 R>>
 endobj
-
 37 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [38 0 R 17 18 19 20]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/Lbl/P 39 0 R/K[5]/Pg 139 0 R>>
 endobj
-
 38 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 37 0 R
-  /K [16]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/LBody/P 39 0 R/K[6 7]/Pg 139 0 R>>
 endobj
-
 39 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 19 0 R
-  /T (Why partner with CNG)
-  /K [15]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/LI/P 55 0 R/K[37 0 R 38 0 R]>>
 endobj
-
 40 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [9 10 11 41 0 R 13 14]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/Lbl/P 42 0 R/K[8]/Pg 139 0 R>>
 endobj
-
 41 0 obj
-<<
-  /Type /StructElem
-  /S /Link
-  /P 40 0 R
-  /K [12 <<
-    /Type /OBJR
-    /Pg 169 0 R
-    /Obj 168 0 R
-  >>]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/LBody/P 42 0 R/K[9]/Pg 139 0 R>>
 endobj
-
 42 0 obj
-<<
-  /Type /StructElem
-  /S /Table
-  /P 19 0 R
-  /K [54 0 R 51 0 R 48 0 R 43 0 R]
->>
+<</Type/StructElem/S/LI/P 55 0 R/K[40 0 R 41 0 R]>>
 endobj
-
 43 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 42 0 R
-  /K [46 0 R 44 0 R]
->>
+<</Type/StructElem/S/Lbl/P 45 0 R/K[10]/Pg 139 0 R>>
 endobj
-
 44 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 43 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >> <<
-    /O /Layout
-    /BorderColor [0.8784314 0.87058824 0.85882354]
-    /BorderStyle [/None /Solid /None /None]
-    /BorderThickness [0 0.5 0 0]
-  >>]
-  /K [45 0 R]
->>
+<</Type/StructElem/S/LBody/P 45 0 R/K[11]/Pg 139 0 R>>
 endobj
-
 45 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 44 0 R
-  /K [8]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/LI/P 55 0 R/K[43 0 R 44 0 R]>>
 endobj
-
 46 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 43 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >> <<
-    /O /Layout
-    /BorderColor [0.8784314 0.87058824 0.85882354]
-    /BorderStyle [/None /Solid /None /None]
-    /BorderThickness [0 0.5 0 0]
-  >>]
-  /K [47 0 R]
->>
+<</Type/StructElem/S/Lbl/P 48 0 R/K[12]/Pg 139 0 R>>
 endobj
-
 47 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 46 0 R
-  /K [7]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/LBody/P 48 0 R/K[13]/Pg 139 0 R>>
 endobj
-
 48 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 42 0 R
-  /K [50 0 R 49 0 R]
->>
+<</Type/StructElem/S/LI/P 55 0 R/K[46 0 R 47 0 R]>>
 endobj
-
 49 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 48 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [6]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/Lbl/P 51 0 R/K[14]/Pg 139 0 R>>
 endobj
-
 50 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 48 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [5]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/LBody/P 51 0 R/K[15]/Pg 139 0 R>>
 endobj
-
 51 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 42 0 R
-  /K [53 0 R 52 0 R]
->>
+<</Type/StructElem/S/LI/P 55 0 R/K[49 0 R 50 0 R]>>
 endobj
-
 52 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 51 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [4]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/Lbl/P 54 0 R/K[16]/Pg 139 0 R>>
 endobj
-
 53 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 51 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [3]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/LBody/P 54 0 R/K[17]/Pg 139 0 R>>
 endobj
-
 54 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 42 0 R
-  /K [56 0 R 55 0 R]
->>
+<</Type/StructElem/S/LI/P 55 0 R/K[52 0 R 53 0 R]>>
 endobj
-
 55 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 54 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [2]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/L/P 112 0 R/A[<</O/List/ListNumbering/Circle>>]/K[39 0 R 42 0 R 45 0 R 48 0 R 51 0 R 54 0 R]>>
 endobj
-
 56 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 54 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [1]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/H3/P 112 0 R/T(CNG NYC Event sponsor: $2,000)/K[18]/Pg 139 0 R>>
 endobj
-
 57 0 obj
-<<
-  /Type /StructElem
-  /S /H3
-  /P 19 0 R
-  /T (For renewing CNG Commercial Members)
-  /K [0]
-  /Pg 169 0 R
->>
+<</Type/StructElem/S/Em/P 58 0 R/K[19]/Pg 139 0 R>>
 endobj
-
 58 0 obj
-<<
-  /Type /StructElem
-  /S /Table
-  /P 19 0 R
-  /K [70 0 R 67 0 R 64 0 R 59 0 R]
->>
+<</Type/StructElem/S/P/P 112 0 R/K[57 0 R]>>
 endobj
-
 59 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 58 0 R
-  /K [62 0 R 60 0 R]
->>
+<</Type/StructElem/S/Lbl/P 61 0 R/K[20]/Pg 139 0 R>>
 endobj
-
 60 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 59 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >> <<
-    /O /Layout
-    /BorderColor [0.8784314 0.87058824 0.85882354]
-    /BorderStyle [/None /Solid /None /None]
-    /BorderThickness [0 0.5 0 0]
-  >>]
-  /K [61 0 R]
->>
+<</Type/StructElem/S/LBody/P 61 0 R/K[21]/Pg 139 0 R>>
 endobj
-
 61 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 60 0 R
-  /K [30]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/LI/P 71 0 R/K[59 0 R 60 0 R]>>
 endobj
-
 62 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 59 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >> <<
-    /O /Layout
-    /BorderColor [0.8784314 0.87058824 0.85882354]
-    /BorderStyle [/None /Solid /None /None]
-    /BorderThickness [0 0.5 0 0]
-  >>]
-  /K [63 0 R]
->>
+<</Type/StructElem/S/Lbl/P 64 0 R/K[22]/Pg 139 0 R>>
 endobj
-
 63 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 62 0 R
-  /K [29]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/LBody/P 64 0 R/K[23]/Pg 139 0 R>>
 endobj
-
 64 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 58 0 R
-  /K [66 0 R 65 0 R]
->>
+<</Type/StructElem/S/LI/P 71 0 R/K[62 0 R 63 0 R]>>
 endobj
-
 65 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 64 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [28]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/Lbl/P 67 0 R/K[24]/Pg 139 0 R>>
 endobj
-
 66 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 64 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [27]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/LBody/P 67 0 R/K[25]/Pg 139 0 R>>
 endobj
-
 67 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 58 0 R
-  /K [69 0 R 68 0 R]
->>
+<</Type/StructElem/S/LI/P 71 0 R/K[65 0 R 66 0 R]>>
 endobj
-
 68 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 67 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [26]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/Lbl/P 70 0 R/K[26]/Pg 139 0 R>>
 endobj
-
 69 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 67 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [25]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/LBody/P 70 0 R/K[27]/Pg 139 0 R>>
 endobj
-
 70 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 58 0 R
-  /K [72 0 R 71 0 R]
->>
+<</Type/StructElem/S/LI/P 71 0 R/K[68 0 R 69 0 R]>>
 endobj
-
 71 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 70 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [24]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/L/P 112 0 R/A[<</O/List/ListNumbering/Circle>>]/K[61 0 R 64 0 R 67 0 R 70 0 R]>>
 endobj
-
 72 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 70 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [23]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/H3/P 112 0 R/T(CNG 2026 community partner: $5,000)/K[28]/Pg 139 0 R>>
 endobj
-
 73 0 obj
-<<
-  /Type /StructElem
-  /S /H3
-  /P 19 0 R
-  /T (For new CNG Commercial Members)
-  /K [22]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[29 30 31 32]/Pg 139 0 R>>
 endobj
-
 74 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [20 21]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/Lbl/P 76 0 R/K[33]/Pg 139 0 R>>
 endobj
-
 75 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 19 0 R
-  /T (Bundle with CNG Membership)
-  /K [19]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/LBody/P 76 0 R/K[34]/Pg 139 0 R>>
 endobj
-
 76 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [15 16 17 18]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/LI/P 89 0 R/K[74 0 R 75 0 R]>>
 endobj
-
 77 0 obj
-<<
-  /Type /StructElem
-  /S /L
-  /P 19 0 R
-  /A [<<
-    /O /List
-    /ListNumbering /Circle
-  >>]
-  /K [90 0 R 87 0 R 84 0 R 81 0 R 78 0 R]
->>
+<</Type/StructElem/S/Lbl/P 79 0 R/K[35]/Pg 139 0 R>>
 endobj
-
 78 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 77 0 R
-  /K [80 0 R 79 0 R]
->>
+<</Type/StructElem/S/LBody/P 79 0 R/K[36]/Pg 139 0 R>>
 endobj
-
 79 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 78 0 R
-  /K [14]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/LI/P 89 0 R/K[77 0 R 78 0 R]>>
 endobj
-
 80 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 78 0 R
-  /K [13]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/Lbl/P 82 0 R/K[37]/Pg 139 0 R>>
 endobj
-
 81 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 77 0 R
-  /K [83 0 R 82 0 R]
->>
+<</Type/StructElem/S/LBody/P 82 0 R/K[38 39]/Pg 139 0 R>>
 endobj
-
 82 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 81 0 R
-  /K [11 12]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/LI/P 89 0 R/K[80 0 R 81 0 R]>>
 endobj
-
 83 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 81 0 R
-  /K [10]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/Lbl/P 85 0 R/K[40]/Pg 139 0 R>>
 endobj
-
 84 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 77 0 R
-  /K [86 0 R 85 0 R]
->>
+<</Type/StructElem/S/LBody/P 85 0 R/K[41]/Pg 139 0 R>>
 endobj
-
 85 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 84 0 R
-  /K [9]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/LI/P 89 0 R/K[83 0 R 84 0 R]>>
 endobj
-
 86 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 84 0 R
-  /K [8]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/Lbl/P 88 0 R/K[42]/Pg 139 0 R>>
 endobj
-
 87 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 77 0 R
-  /K [89 0 R 88 0 R]
->>
+<</Type/StructElem/S/LBody/P 88 0 R/K[43]/Pg 139 0 R>>
 endobj
-
 88 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 87 0 R
-  /K [7]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/LI/P 89 0 R/K[86 0 R 87 0 R]>>
 endobj
-
 89 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 87 0 R
-  /K [6]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/L/P 112 0 R/A[<</O/List/ListNumbering/Circle>>]/K[76 0 R 79 0 R 82 0 R 85 0 R 88 0 R]>>
 endobj
-
 90 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 77 0 R
-  /K [92 0 R 91 0 R]
->>
+<</Type/StructElem/S/P/P 112 0 R/K[0 1]/Pg 140 0 R>>
 endobj
-
 91 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 90 0 R
-  /K [4 5]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/H3/P 112 0 R/T(CNG membership renewal + community partner: $8,000)/K[2]/Pg 140 0 R>>
 endobj
-
 92 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 90 0 R
-  /K [3]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[3 4]/Pg 140 0 R>>
 endobj
-
 93 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [94 0 R]
->>
+<</Type/StructElem/S/Lbl/P 95 0 R/K[5]/Pg 140 0 R>>
 endobj
-
 94 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 93 0 R
-  /K [2]
-  /Pg 166 0 R
->>
+<</Type/StructElem/S/LBody/P 95 0 R/K[6]/Pg 140 0 R>>
 endobj
-
 95 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [32 33 <<
-    /Type /MCR
-    /MCID 0
-    /Pg 166 0 R
-  >> <<
-    /Type /MCR
-    /MCID 1
-    /Pg 166 0 R
-  >>]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/LI/P 99 0 R/K[93 0 R 94 0 R]>>
 endobj
-
 96 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [30 31]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/Lbl/P 98 0 R/K[7]/Pg 140 0 R>>
 endobj
-
 97 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 19 0 R
-  /T <FEFF0043006F006D006D0075006E00690074007900200050006100720074006E0065007200202014002000240035002C003000300030>
-  /K [29]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/LBody/P 98 0 R/K[8]/Pg 140 0 R>>
 endobj
-
 98 0 obj
-<<
-  /Type /StructElem
-  /S /Table
-  /P 19 0 R
-  /K [119 0 R 115 0 R 111 0 R 107 0 R 103 0 R 99 0 R]
->>
+<</Type/StructElem/S/LI/P 99 0 R/K[96 0 R 97 0 R]>>
 endobj
-
 99 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 98 0 R
-  /K [102 0 R 101 0 R 100 0 R]
->>
+<</Type/StructElem/S/L/P 112 0 R/A[<</O/List/ListNumbering/Circle>>]/K[95 0 R 98 0 R]>>
 endobj
-
 100 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 99 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >> <<
-    /O /Layout
-    /BorderColor [0.8784314 0.87058824 0.85882354]
-    /BorderStyle [/None /Solid /None /None]
-    /BorderThickness [0 0.5 0 0]
-  >>]
-  /K [28]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/H2/P 112 0 R/T(Why sponsor CNG NYC?)/K[9]/Pg 140 0 R>>
 endobj
-
 101 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 99 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >> <<
-    /O /Layout
-    /BorderColor [0.8784314 0.87058824 0.85882354]
-    /BorderStyle [/None /Solid /None /None]
-    /BorderThickness [0 0.5 0 0]
-  >>]
-  /K [27]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[10 11 12 13 14]/Pg 140 0 R>>
 endobj
-
 102 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 99 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >> <<
-    /O /Layout
-    /BorderColor [0.8784314 0.87058824 0.85882354]
-    /BorderStyle [/None /Solid /None /None]
-    /BorderThickness [0 0.5 0 0]
-  >>]
-  /K [26]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[15 16 17 18]/Pg 140 0 R>>
 endobj
-
 103 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 98 0 R
-  /K [106 0 R 105 0 R 104 0 R]
->>
+<</Type/StructElem/S/H2/P 112 0 R/T(Get in touch)/K[19]/Pg 140 0 R>>
 endobj
-
 104 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 103 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [25]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[20]/Pg 140 0 R>>
 endobj
-
 105 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 103 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [24]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/Strong/P 107 0 R/K[21]/Pg 140 0 R>>
 endobj
-
 106 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 103 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [23]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/Link/P 107 0 R/K[23<</Type/OBJR/Pg 140 0 R/Obj 114 0 R>>]/Pg 140 0 R>>
 endobj
-
 107 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 98 0 R
-  /K [110 0 R 109 0 R 108 0 R]
->>
+<</Type/StructElem/S/P/P 112 0 R/K[105 0 R 22 106 0 R]/Pg 140 0 R>>
 endobj
-
 108 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 107 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [22]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/Em/P 109 0 R/K[24]/Pg 140 0 R>>
 endobj
-
 109 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 107 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [20 21]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/P/P 112 0 R/K[108 0 R]>>
 endobj
-
 110 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 107 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [19]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/Em/P 111 0 R/K[25 26]/Pg 140 0 R>>
 endobj
-
 111 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 98 0 R
-  /K [114 0 R 113 0 R 112 0 R]
->>
+<</Type/StructElem/S/P/P 112 0 R/K[110 0 R]>>
 endobj
-
 112 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 111 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [18]
-  /Pg 164 0 R
->>
+<</Type/StructElem/S/Document/P 13 0 R/K[20 0 R 21 0 R 25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 35 0 R 36 0 R 55 0 R 56 0 R 58 0 R 71 0 R 72 0 R 73 0 R 89 0 R 90 0 R 91 0 R 92 0 R 99 0 R 100 0 R 101 0 R 102 0 R 103 0 R 104 0 R 107 0 R 109 0 R 111 0 R]>>
 endobj
-
 113 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 111 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [17]
-  /Pg 164 0 R
->>
+<</Type/Annot/Subtype/Link/Rect[356.175 624.2163 460.125 641.5203]/Border[0 0 0]/A<</Type/Action/S/URI/URI(https://cloudnativegeo.org)>>/F 4/StructParent 0/Contents(https://cloudnativegeo.org)>>
 endobj
-
 114 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 111 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [16]
-  /Pg 164 0 R
->>
+<</Type/Annot/Subtype/Link/Rect[238.05 319.5345 395.55 336.8385]/Border[0 0 0]/A<</Type/Action/S/URI/URI(mailto:michelle\\@cloudnativegeo.org)>>/F 4/StructParent 3/Contents(Email michelle\\@cloudnativegeo.org)>>
 endobj
-
 115 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 98 0 R
-  /K [118 0 R 117 0 R 116 0 R]
->>
+[/ICCBased 153 0 R]
 endobj
-
 116 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 115 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [15]
-  /Pg 164 0 R
->>
+[138 0 R/XYZ 64.8 603.2038 0]
 endobj
-
 117 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 115 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [14]
-  /Pg 164 0 R
->>
+[138 0 R/XYZ 64.8 519.0988 0]
 endobj
-
 118 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 115 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [13]
-  /Pg 164 0 R
->>
+[139 0 R/XYZ 64.8 704.83203 0]
 endobj
-
 119 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 98 0 R
-  /K [122 0 R 121 0 R 120 0 R]
->>
+[139 0 R/XYZ 64.8 457.968 0]
 endobj
-
 120 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 119 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [12]
-  /Pg 164 0 R
->>
+[139 0 R/XYZ 64.8 310.749 0]
 endobj
-
 121 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 119 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [11]
-  /Pg 164 0 R
->>
+[140 0 R/XYZ 64.8 699.367 0]
 endobj
-
 122 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 119 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >>]
-  /K [10]
-  /Pg 164 0 R
->>
+[139 0 R/XYZ 64.8 748 0]
 endobj
-
 123 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [6 7 8 9]
-  /Pg 164 0 R
->>
+[140 0 R/XYZ 64.8 584.802 0]
 endobj
-
 124 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 19 0 R
-  /T (The 2026 CNG event series)
-  /K [5]
-  /Pg 164 0 R
->>
+[140 0 R/XYZ 64.8 391.098 0]
 endobj
-
 125 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [1 2 3 4]
-  /Pg 164 0 R
->>
+[138 0 R/XYZ 64.8 675.1908 0]
 endobj
-
 126 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 19 0 R
-  /T (About Cloud-Native Geospatial Forum (CNG))
-  /K [0]
-  /Pg 164 0 R
->>
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 115 0 R>>/Font<</f0 129 0 R/f1 132 0 R>>>>
 endobj
-
 127 0 obj
-<<
-  /Type /StructElem
-  /S /Span
-  /P 19 0 R
-  /A [<<
-    /O /Layout
-    /Placement /Block
-  >>]
-  /K [4 5 6 7]
-  /Pg 162 0 R
->>
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 115 0 R>>/Font<</f0 129 0 R/f1 135 0 R/f2 132 0 R>>>>
 endobj
-
 128 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 19 0 R
-  /K [129 0 R]
->>
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 115 0 R>>/Font<</f0 132 0 R/f1 129 0 R/f2 135 0 R>>>>
 endobj
-
 129 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 128 0 R
-  /K [3]
-  /Pg 162 0 R
->>
+<</Type/Font/Subtype/Type0/BaseFont/DGOKRY+iAWriterQuattroS-Bold/Encoding/Identity-H/DescendantFonts[130 0 R]/ToUnicode 142 0 R>>
 endobj
-
 130 0 obj
-<<
-  /Type /StructElem
-  /S /H1
-  /P 19 0 R
-  /T (CNG 2026 Community Partner Program)
-  /K [1 2]
-  /Pg 162 0 R
->>
+<</Type/Font/Subtype/CIDFontType2/BaseFont/DGOKRY+iAWriterQuattroS-Bold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 131 0 R/DW 0/CIDToGIDMap/Identity/W[0 3 600 4 4 450 5 12 600 13 13 450 14 14 600 15 15 300 16 17 600 18 18 450 19 21 600 22 22 900 23 26 600 27 27 900 28 29 600 30 30 300 31 48 600 49 49 900 50 50 600 51 51 900]>>
 endobj
-
 131 0 obj
-<<
-  /Type /StructElem
-  /S /Figure
-  /P 19 0 R
-  /A [<<
-    /O /Layout
-    /Placement /Block
-  >>]
-  /K [0]
-  /Pg 162 0 R
->>
+<</Type/FontDescriptor/FontName/DGOKRY+iAWriterQuattroS-Bold/Flags 131076/FontBBox[-8 -212 908 811]/ItalicAngle 0/Ascent 780/Descent -220/CapHeight 698/StemV 168.6/CIDSet 141 0 R/FontFile2 143 0 R>>
 endobj
-
 132 0 obj
-<<
-  /Type /Font
-  /Subtype /Type0
-  /BaseFont /VQUQSI+iAWriterQuattroS-Bold
-  /Encoding /Identity-H
-  /DescendantFonts [133 0 R]
-  /ToUnicode 136 0 R
->>
+<</Type/Font/Subtype/Type0/BaseFont/NJSXLV+iAWriterQuattroS-Regular/Encoding/Identity-H/DescendantFonts[133 0 R]/ToUnicode 145 0 R>>
 endobj
-
 133 0 obj
-<<
-  /Type /Font
-  /Subtype /CIDFontType2
-  /BaseFont /VQUQSI+iAWriterQuattroS-Bold
-  /CIDSystemInfo <<
-    /Registry (Adobe)
-    /Ordering (Identity)
-    /Supplement 0
-  >>
-  /FontDescriptor 135 0 R
-  /DW 0
-  /CIDToGIDMap /Identity
-  /W [0 3 600 4 4 450 5 8 600 9 9 900 10 11 600 12 12 300 13 13 450 14 16 600 17 17 450 18 29 600 30 30 300 31 38 600 39 39 900 40 42 600 43 43 900 44 44 600 45 45 450 46 47 600 48 49 900 50 54 600]
->>
+<</Type/Font/Subtype/CIDFontType2/BaseFont/NJSXLV+iAWriterQuattroS-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 134 0 R/DW 0/CIDToGIDMap/Identity/W[0 3 600 4 4 450 5 10 600 11 11 450 12 12 600 13 13 450 14 16 600 17 17 300 18 18 600 19 19 300 20 20 450 21 21 900 22 23 600 24 24 900 25 43 600 44 44 900 45 60 600 61 61 300 62 62 600 63 63 900 64 66 600 67 67 900]>>
 endobj
-
 134 0 obj
-<<
-  /Length 12
-  /Filter /FlateDecode
->>
-stream
-xœûÿ #ez
-endstream
+<</Type/FontDescriptor/FontName/NJSXLV+iAWriterQuattroS-Regular/Flags 131076/FontBBox[17 -212 876 780]/ItalicAngle 0/Ascent 780/Descent -220/CapHeight 698/StemV 95.4/CIDSet 144 0 R/FontFile2 146 0 R>>
 endobj
-
 135 0 obj
-<<
-  /Type /FontDescriptor
-  /FontName /VQUQSI+iAWriterQuattroS-Bold
-  /Flags 131076
-  /FontBBox [-8 -212 908 811]
-  /ItalicAngle 0
-  /Ascent 780
-  /Descent -220
-  /CapHeight 698
-  /StemV 168.6
-  /CIDSet 134 0 R
-  /FontFile2 137 0 R
->>
+<</Type/Font/Subtype/Type0/BaseFont/DYIPWL+iAWriterQuattroS-Italic/Encoding/Identity-H/DescendantFonts[136 0 R]/ToUnicode 148 0 R>>
 endobj
-
 136 0 obj
-<<
-  /Length 1362
-  /Type /CMap
-  /WMode 0
->>
-stream
-%!PS-Adobe-3.0 Resource-CMap
-%%DocumentNeededResources: procset CIDInit
-%%IncludeResource: procset CIDInit
-%%BeginResource: CMap Custom
-%%Title: (Custom Adobe Identity 0)
-%%Version: 1
-%%EndComments
-/CIDInit /ProcSet findresource begin
-12 dict begin
-begincmap
-/CIDSystemInfo 3 dict dup begin
-    /Registry (Adobe) def
-    /Ordering (Identity) def
-    /Supplement 0 def
-end def
-/CMapName /Custom def
-/CMapVersion 1 def
-/CMapType 0 def
-/WMode 0 def
-1 begincodespacerange
-<0000> <FFFF>
-endcodespacerange
-54 beginbfchar
-<0001> <0043>
-<0002> <004E>
-<0003> <0047>
-<0004> <0020>
-<0005> <0032>
-<0006> <0030>
-<0007> <0036>
-<0008> <006F>
-<0009> <006D>
-<000A> <0075>
-<000B> <006E>
-<000C> <0069>
-<000D> <0074>
-<000E> <0079>
-<000F> <0050>
-<0010> <0061>
-<0011> <0072>
-<0012> <0065>
-<0013> <0067>
-<0014> <0046>
-<0015> <0076>
-<0016> <0063>
-<0017> <0073>
-<0018> <002E>
-<0019> <004F>
-<001A> <0070>
-<001B> <0068>
-<001C> <0041>
-<001D> <0062>
-<001E> <006C>
-<001F> <0064>
-<0020> <002D>
-<0021> <0028>
-<0022> <0029>
-<0023> <0054>
-<0024> <0045>
-<0025> <0044>
-<0026> <004C>
-<0027> <2014>
-<0028> <0024>
-<0029> <0035>
-<002A> <002C>
-<002B> <0057>
-<002C> <2019>
-<002D> <0066>
-<002E> <003A>
-<002F> <0042>
-<0030> <0077>
-<0031> <004D>
-<0032> <0056>
-<0033> <0039>
-<0034> <0038>
-<0035> <0053>
-<0036> <0052>
-endbfchar
-endcmap
-CMapName currentdict /CMap defineresource pop
-end
-end
-%%EndResource
-%%EOF
-endstream
+<</Type/Font/Subtype/CIDFontType2/BaseFont/DYIPWL+iAWriterQuattroS-Italic/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 137 0 R/DW 0/CIDToGIDMap/Identity/W[0 1 600 2 2 300 3 3 900 4 4 450 5 11 600 12 12 450 13 14 600 15 15 300 16 36 600 37 37 450 38 39 600 40 40 300 41 47 600]>>
 endobj
-
 137 0 obj
-<<
-  /Length 7484
-  /Filter /FlateDecode
->>
+<</Type/FontDescriptor/FontName/DYIPWL+iAWriterQuattroS-Italic/Flags 131140/FontBBox[-71 -212 817 780]/ItalicAngle -9.5/Ascent 780/Descent -220/CapHeight 698/StemV 95.4/CIDSet 147 0 R/FontFile2 149 0 R>>
+endobj
+138 0 obj
+<</Type/Page/Resources 126 0 R/MediaBox[0 0 612 792]/StructParents 1/Tabs/S/Parent 1 0 R/Contents 150 0 R/Annots[113 0 R]>>
+endobj
+139 0 obj
+<</Type/Page/Resources 127 0 R/MediaBox[0 0 612 792]/StructParents 2/Parent 1 0 R/Contents 151 0 R>>
+endobj
+140 0 obj
+<</Type/Page/Resources 128 0 R/MediaBox[0 0 612 792]/StructParents 4/Tabs/S/Parent 1 0 R/Contents 152 0 R/Annots[114 0 R]>>
+endobj
+141 0 obj
+<</Length 13/Filter/FlateDecode>>
 stream
-xœ­z	p[Ç™æ×ý@ð€ ‘zà@xàOA I)Š”,ÀV$@$uÄÖIÖa%‘-™v;áäØdãL6'žŒ§A9¶Ì$¶ÇµñŒ“l’rM’Ù$•ìªfœÌlÕTgÖ•ŠÀ­îR¤|L¦fÉúÝßëþû¿»I å¸	mÓçÎªŽý-ø6€>uäøc5oäq Êuä¾‹‡7Mþý ú+À¦WÎægê;wí‚3 bGÎæ•¤_‚_ à;züì…‡?Wõ
-|ÀÍûNNç¿»ÿûã@è+ ÎÏ_8%=a»Ðk¨'òÇg“˜¾èq€¾uêä™³æå€VÀü©Ó³§æþçwR@ëó ~ÿÏçð9œÀ	ºPXŽÓ×——¨myi9¾nì&­\ý'ºQŒß‹{1†1ú:IóÏøÛ³ÝóéèANÁntc6“äüòïîì§‹d}•¤ ]eØ›ÊªêèTíeÊÔÝÖéaMÙÜauno†Qþ%,˜žÖy¼^†,CJ\ A*—3¢35w8Ì¨®y5o˜Iº:s]rºL1GJÍå’êL%~)ÅhjÏ•UhŒ¦Rù&O\X ”¦rIæÝìå½U.’Ü¬2šÒ’âHå’ÃDf6»PC82ÌdI!æJeøz¬&•*<êŒÊ^`ràî…&R™šbÊPÆË$vòžŒWózæ2*›˜ÈxY"ëQYœSñlV-èükšÈxKO*kããmùêDF=¬ÎÍåUfÈä<*Sù˜•S1NÅrž\6›õ0êg©i†ÉÃ({YEÊ3Êê9U?š¿aÃ4GÜ0áP6;“Ï2ÊfK;Èª3¬&¥%³afÒÕ!•ÉþüŒÊÌ©‰3kIfÑ’¯7ËH.Ì!n&…Ô™‚ùPRåƒ|»ƒ}þÍ”ÜÐ43½*³¤Ô9uŽ‘P¡Íägr`w&7áÉOf3ZÖ›UYb*ÃHÈÃåRb%ÌÌ:+K…@5[tV¦%5•AKæ=t˜‘iFrÌ³2]åÜV¥¦oÈ8¤òX"—åÜ àÖª/”U!5”zW§\_oHÆ,$¤1¤˜ìÏ©CsZž+U®¦zXbU`LòkùAc‰Ê÷xù&2üåÄ»½TÅí_K^¯¬€44‘ñz4o6è³j½@é›É†™Mg$§ª¬:µ“O ²j-™e6þ4™Q™MèË®«Ì&„¢Þ1=§å™=•Sçr*³kI-Ì6è£{2yf0ëc•³Ú…0sè£»3£SF§Ç›õ1‡èwêlHíÍ6lH1’O2{ˆ»£þd¡šÙ¨?ÉH¦2É?‘)pñ1ÙŸœ›Sù²¶ Wc$¿B{Œqþ
-õ‹ž,«N0[j$Çèze½‡
-€Cd$Å0°@Úré(€íÉ°ZRbUZ’UjLÉ%UæÔ’jŽ‘ü‹µµv8L&¹$œ©+8-!öXÈÓ³½ W(ÌÜzð¶V/PÞnÔo7é™·½`âíf½ ð¶N/˜y[¯,¼Ý¢ÊxÒµE0%7º'£©-Œ|€»M˜ékkV?d†×VOƒªVz¯ó½~ÓØ+ßèÚýyõÔP˜5èÂ[M/PÞúô‚Ä[¿^yÐ&Þ6ê…·MzÁÌÛf½`ámP/”ñ¶EWû„å¶êjŽÕæÔ”ÆHŽGž{c7Þ6µ†Xk0ÌÚuUQßC­Z>®ñÿ¾ß}ÇŠ®UÊ7=Ö,˜ˆk(Ó–»Œ¬Ï{a:u5*8ê(a†Þ¹&#¡wå…÷£†'a`p@‹:‰‹ï5¦«}êÈ{ðÏÊÇÃ¬Koq÷…Yüß‚2’šŽ‡Y·^ ¨ñ«-êŒúwÌÍh#Z^Íòðð«%â„¸œÁ0ëÑj˜[K2ÙÏd¿€*då©Ðì\‹¦ª}sñ0ë]S[Œù˜¢%WÐ*Ëñà’Ø¹.«&Õs]˜6e“<äZSêœ&ÞÐ†sLIÝé·9öŒô$§r33¥ò3&§òfJåxÈ»ó¼¦ªLhÃù¸GcÖÔ0O]Ö”X%§¾Û"š\•TŽ+ÃäÏ3Ó;fer€3áçLHþÜL)¤Þ^+f}+²PU•™%Yh}ñ0ë_bV1>¬ðE¹VEÈ7cHšaO¦EíÓ¼"ñ–:UÎWILñ3“ÇÚ"ÆPâ»Y{I[7ù­k8I­¨+Ç+;·¼¢â„®©-\ŠÃÌÊLx&³µ/ÛRh#ÎP˜m[7:é™X7š|×wßï”ÎzBï·à ÎzCsªÚÇml.þÞP¦¤ZX[(Ì†Ä–¹}ÉçY…–4¶ÎTSûÔ-^šX/Xerå•§Iüÿ²b¾'Çú´¸Ç»Æ^¼ÙŸ#z=¡©l×èy¹Î8£¥Ý¬Š`‡Îà2Ü~ÜÃ-,³ïÑ?ª@œÖ³´Îºƒa6Æ¥8¤©-êðœ–_‘Ö¸Îš…Âl—¾ ‡ÂlB_ áÄn}ˆžI}ˆž)Ž	…ÙŽáÄ^ŽáÄ]Ã‰}úu ©P˜eôë¼†
-…YV¿NŒ¾»õëÄè»‡ã§ösœ >Àq‚:Àq‚:È×
-…YŽ¯É‰<_“‡øšœ˜æ˜í¡0›áNÌr's'Ž¾CavTðÅ©c‚/N}PðÅ©{_œºOðÅ©ã‚/N|qê¤^@ßªO‰'–…Ù‡r[(ÌNs¡‹§d(ÌÎèRÂœ5HŽ¹_`H	sN/ uÖóâI¼qÁ ù’ÃÐ¤xÐ 9à’.é¬Î÷xð$‡_6Hÿˆ^ %ÀG’>fpE/`ëê|‹'Ä 9üªArø5½@J€G’æ’ÓÊE‰ËÏ‚L¥¡Œæõx³ÙdˆYf™ä›¸°’¬Ã<ÅR¨ K`Fs"Àû$Ð#2‘‘öÉD’ÈA‰ì’eÙ,›7Øm&ecÈáµ{ýv¯]¥µ·Þ"Ï™Tñû¥:xëÛ AóòÐ×Q‹–D¨Æe1Ë”4AÀŽ1P*åùÔ;¥q µpû}>“uc¨&íŒE:Üæ@@kP\.gM¤#ÖåV´…G{£åñÊ¶öÞh´·½­òñ–7*ÿüÏßhˆ÷ìß÷À¾ý=ñ†7øÚý õÐE”CKð³==(JSc$’3q[#ãvþcS¬›CÍ®Ù#Žˆ=b×þªüòóO—_~žü¸ØF‹mäÇ·†¹Œ´å%ê¥¯CÅ‡^¨¬ ŠDÒ£Ì9‘áâ’‰r
-L²b:I¢yPºc²LòfBÈN2îIÙ,Ãün@³yÐ@C€³‰r»Ýá÷ùlk}È¯)ŠÖðnr‰FµhÄ®‘Ï—9Æú¿òÈw[¯jiíj´wž¿õÈtûÀ·¾öü·ÞhˆõÝ“9}w¾·-òÁâc|?€†èëØ„Æ„¯²‚J’¡žŽ$	¹oc¼Ö×d“­›B^o´+‹F;Zƒ¹1‹tÔÔ¸œŠb6{i¨hýyO{§¾oóÇ6^9:z¼»m|àa2ñè‹Û­¡–C»¦cû»öµÏòí§¯£¡¡?ÑÙBL’l:JKöaæV—WámÚTQlÒ65l©«ØXQë°£V_™Õ½b.œm…;C:h´3Òár9µ/_½:7wõê\"OðÏÀÀÀ€°þ9wÏ¾î»G|Ýh«ik«i>X^¢ÝtnøKD*¸/¤A ÉDú Æc
-‘eš7JwÒñÚZ Ö_ëÛR7jn³µ6Tà¼Åº"Šbvß–×lþâÂÖg’?úø“Î²š=cÉ»¢ñîh¤'­¼´gÿ3Õ§¿pPjí‰Mo99pwgUgW<RÕÙÍùä~ÖJmB–z¢yE€é1“ l‹oà”÷Üõ¹¹‹çæ.vÄãüSñÔ¥KOñÏ‰îÉîñ%|b¶R®Ã]/”Q*cÅ'\\6ÈSB9'f•¤AiÜ“Ø`XŽä)!äöX6Qîhph¿OX¼#âŠ‰¹Æe×ìƒœ0Ú¡y¥z¤+–¶KÕûzÒ»ç5¿/2¿]ëœ§•Ù–®XgKßñéâ‹¤?ÒÞä/~ƒôÏðFðÝ¿¼DÝT†“‚ßo‚€’´ç› 2%é¬±‰!d˜*’	°ãžDM©S–ˆì‹v‡æÐLVÏª³Ú#vÃEy\!S£=éýózÈ›Ÿ?ÐÖsx?/¾ÞiÒÈÔ­ß1f›ˆ[68‘þ¦D¤Uq:¸7æ	áÂ3É”ÒA:îI¸…0yLãQ#½:’MTpÂ©9|vÅº)±¯Hs·Í¯áˆÊ‚£âéáÿÀò2F üý4Ä—	¯è|òyº‡È²Ì}Ré 7¹á1Éa5È:¼fk]Èï¬‰D\\0<dE#®ˆK#Îª}'Ç'ffæ/^üã*ç™Ýƒ¿?óÂgøŽå8¢2ìhHl©.§$-		€R1ÿv2îðj"4‘ˆ¤(šttuI·;ÒEžûÌ?»Ç‡sue5?~z´Õ¦ò­¯÷öœÙ4@ÉÏ>ýi±›4@Ûè"¬p"”h‚B%r²,b_jŒ;÷ œ*Ëa…ÕçU¬µ¡ˆÝkøæ²‹ ÜÐ´4©:|êÔáó»;ƒÁÎÝtñü‘#ç‹ä|SK}K(:——hµÁ‹0žHT¹ˆ$;	ºf“TR³
-ÅDžä<d9=“	yb¡ÀàX1›W¸)6¿;ü …¬ o§OCAC¸Aoô«õÝl•å^âµZkBÞ†@ãJ†‰DŒ@P
-ð"D\>žhJÑü}K·lªÜÓ—¾û­)½Cïuïöœžº÷œ³Ê]\îÜ¥·6ûÚBÑÉíOojmiØ²½¥k:÷j•óÞ½ÚÀ–z§g³aë# ùOTF%¼‰zJ$JÒ"vVVÔ+¢°î÷#ófÿeÇD´gžÊŸüäµ­íÅ%Pt,/Ñ€ð:$ý6B‰H”¦!ƒP™1.KEí¡µ‡Ë¸ê\›7ºá„Csø,·k—Ë+òl—[Q4ª¸\B:‹×®ž=óHñéDÏdlÂ{b¼¯ûÇ]mO<ôá§>~Q/‹ô%ö5w…Þ‹¥£WØYã²Në¨›ÄË¥à²‘˜¤
-B…j" rÚ#:åõ¥Xä…Éd”Ké13Q‘¥Çx9Å#Ð8Æ=£L›È$üåanRïNhf¢€…»ã…5¨l6Q]WW¬k8}­ÁbÝò;­¡±«T{Ü.KjÜ‘h„®K#´îáËsÛwEÒ½=f×ŽÞì±cÙÞ.óü÷b±`{WWû–³=íí:‰ì¡‡>ï8P¼ÔÔøPcS,à62Ð-te"ÎPH2•ŽpW¼S–e^=–¡Œ‡#Øy]â×>A~TüKR[|‹.>ø¥‹?7ìÎÐ~*£ŒÛLxX1LNZñu>›Ë.s?7bIWDzó¥/¤Ú-í©O¿Då_|ã¿à› oy‰n¡6l|×7}g»µÿF«hùØc?ßwººµ±#ïlŠl8UwbªâÉ‡.=õÐ€×ßÙÓÙã×½)±—öå%ZCmð£3Ñî$”¸$Ê££‰;S)/ XË…>_¨ÄEI‘ÆÆÀz–œ5n·(W´ÿqYJLë[¼Séì¥“ŸÜY»³-¨oñNŽe:]ÑÞìq:L•ÃC»÷ïÚãQ=]¥Ç†ÌkX€„‰ž÷WJKÎ$»du‡ü.-J®½´°°`œIÖÖˆkêšÿºf¥ìïììçŸÕðâ=Ù‹Ù»ïÎ>½[¬Ý»§íÔ†P1“°R"£šP-ÅéÍ<A”•BL&á_;yÌÚÎ‹~âBIþï€dU‡Cul	8}>›Ùê¹]îp¦y4¶kXÇzïü:"þ®®ö`,¤òŽøÕ«W¯Æ;ŠKZûc±þ¦ÆÏ66­©'nÂÉk|jT°ÀÐššŸ‹é8{6^¼ðSÐ;
-®u¥Â<½Y|íÅ…	 Stf”#Ð DÆQðs—I¢¢ Ê­0Ã,\ucÈÛ¨™5GÄA4)B®ë¯„>û7¿Sü™eðÉ¯}.Þ¦ÍÅ·KúX¢íô¦ÐÇyC\)ÄPŠgåA2Ñ•xÉ“ÌÐ;tÀ]|'-©hí0O7kôDßUEöõ*ri¾?LE7‹¯­èèÀ‘5ú!nzV‹@ÈQRò2gãefY‚•XekM(ÒPª(#®7?5o·yŸ¤{n1›ýŒÈ/K´îùT™€Àñ°N>”Þ)ä¥•*W½cxU>Ây½»*»Ó§qù¬=£Ö¸Åa:°N>äÑuò™•ÒÀª“[›Ñ!àqü–ü€\€„ú„<®îãv}²kMðèŠz]“ÄoŸxBØýsËçèú6l²Ú‰L¢|%iñƒ¸mÍTà3eŸw;¨µ6´Á8¬qvÝZ>?Ð3?såÊÌ|Ï8ùãçæBC}þðù¿
-Í=w ÃËçÈ³ë×1æ$C\Š6€ì+­M°ºŽOQÌ¥ØÔ©§.òìÚ…~öŽujš¾Åsw&zP8Öj5œŠub×ìZÔë"ç?ým¢[oýÝúàƒFæù´JÜ‹´ŠbóŽ|
-Y6äZ4ñ9ËQ..I¸vW³ªËëš /Jê‹ÿ‹4‰Ìúõ¹& £‹°À&ü¿t!FÈdŒ[Ëª+ËlV›O5YkCŽ’7i]Ñh§¦Ù¿~lnî±_ÿä#IÑÅëÏ>{ýÜ×>üL±Cð¾¿T˜°ExwŠW*4w;k›`²YÛÎ¹Ýÿ¢ÓÅ[ñ ×–¤rj®;•o·q•8¼.ï0}û–…¿(«~ù4.… " áD0ØìÓêÝ5N‡½Ê¬Èl<œ®ŸlË>™;À3«;j$Õ®hÄUã6]FF5»4ZãŽ*®FW,zkÇiß¾þ½îŽåNŸMÞLdŸ×?üÞÀˆUé
-ÜVyC¶ÛµçÞÊcG«Ó¹–ªgä‡ÇöœµßGÇ¬Ÿ)ßVü'­ì¿Ú¶z./Ñ.º½‰x}Ý&Ë&^—P%¦Ë<XËÔÄtÊA(ŠP¼t¢@pø}»ŸØˆ×YskÁ«>£ì3.€^ZYüŽ­¬vgO¾'ñàÞ?<îIEºzz;Rúƒ›Hvý"Ú9µõ‘»Z:û:-íñv;áÿ ‚g—‘?Ásï§“®ˆ¤ýï—=ñ\ñ[âå·éqº÷{™$ñ#²¸dàf&Ž.»Ë%2™q¸#]ŽÒ·¤IšYÒ,ŸIú%}ì«ã!ÉŸzòË–i´Ìst±Xxí5²Ëø¾5LøÜçŠ|¾B¾H^ 7!ÁÁz5Œ”Ì&"io¿<wœÞ,.ø€üz³t6–$á©Cc&
-òªexŠ2¨Œó“±fHÚÁOÄ+'~2¶kíß?1~õd•óÌ™yòÔ™ÑÁÝgœU£gŠ'——zŠšÐÀ#1‹ï)”¹A¦X4Äíw :]D%Üðò;6…˜(I+ÄÐþ‘Ûjæ×1%ÝX[]¥Ö×z7zkœUîjw³jYuT³Kx«×±râuÝ¦Æþeöäék:T\ú~¬µ5ÖîjoïJÓÅ™»N{ï#™£ä“¾p}X{¥øk]Kà»Fý
-H{h%\¼>±Y¨Ä«q“L¤õõ¸.®V^Ý;Œz¼T•kšÙ¬I¯F|r°ïjHöE}êó	¿äK|öS´òÍ/}éMþ¹õÏ¿¼ví—üŸ®ÎR5]„j¢Îf•ù­7"BRc¥ÄkwØkÄ­‚ÙÜØXºvDìš^Š\{8*}âOþ”~ýËŸ ß;üÿõD±•._"#·†É÷øüe Ý%Î,ëÎ©÷8_”Ìóµ—ž™l¶§ž~‰.ÿóoiãÞ™b@;èëâ²5¡[‘IÚÄ/œ!“ck®»ÚZ~	Ù8¸´`ä™®F‘šÅe¤pgeý9­ã÷S¶þMO<‹wGÉÞ;î/í·âRÄJßòí¤¯£!tc0±Í¥PY"i3‘ ›$yÍµ®…˜L«×ºº^_èÝz<Ò^ªú5ÔasØ¸Ö5Bç®yä,Å¢ë6°þéoÏoMÄÝ'ÒéÝ‰XbtëùÉöh¬­-mÄ»:ùÝiEçz·Ýe·8'zbS­­S±ž	§Å~×¶Þt’gÂMÕápcuS¸øƒ¶fg°µ5èlnãºÝ²¼Duú:ùy«†Pâ~çykÇç­Fü!ÿêyëÎÏ­áöKÑ~p¥yŸÿž¶hw(²ãîÌ•óãöno™Õ;wìÝßqoEw$×ÜÜö,ÕÇ&fNµëÕ†)Í_VY=³;y¤gånk äÿ‰Ö2"ÉÜûeH¥#0™„Ë§Æ¨aóÕU†ÃÛk¼63?Fk¥;.³C“´®UGÿÕ<¿æÚÖóèWîº‹ßtÝÅoºvÞk+þ†HgÅe×÷„oó“Æ¯¨\Š›âDd\	–â¦]KÏÏSùÖïAðK:J.Ñß@BcA™LlæÈ¾•£"ÁÚb¯ `ðÓâ¥§éo¾øE^dÿúBìç«ûþfé-î:SñäOyûwì+_–¿,?3ÇŠÂÿpSü?€ÌŠÃÅÿ.YÌ´ö§›f Òšiý4¼Ð4O©m–®`¨4¾è!¯!H3pÐÒ4ƒNòFh4ƒFšÁDéÝ>šA;ÍàG¥ç^þ>ÍÀÄi¢šã§<G3¦Ô–ÞOÐöKWD_=Íˆõž•®,¿M3x…¼††Ò¼cÒ´KWpŽfPF3ØB3ð•Ú4Ñ¿ÄQ|¿ÃïHœÌ‘_ÒÍôýoR…T+í”þHZ{äC23¥MçL_0ý\iSv*×”47˜'Ìß6ÿÊ’¶µ|ÁòcËRYCÙdÙ©²¹²·¬=Ö=Ö'¬_µþÔúÛò¾òså_-ÿa…Z1_ñÛÊ`e¢2'$Ýï£G¡€âyÀÇòV•?K¢sü>V.pZhŸÓüïV§K4…Ÿ-ÑøR‰–Ñ†_•h6[‰V$ÁmAŒì)Ñex’¬¬UŽº©DW ö!…“8…‹8c8‚£8hC;º b’ƒ*P§q
--P‘Ç	Ì@Å1lˆ˜ýÛpîƒºf¦3âig0‹Ó8‡YÌ ¥ôÞ>;+FTìÆýÈã,Îâ4NBÅ’8‰û0ƒ´ Müöb/F±ãès¬aýûS¯¾ÿ‡­¦®âï˜38†“8!d±²þ¾&—Éa!±ã±2×6œÆ4Ž–f˜.IhE‚c8†{1+p‡pÇp÷B‡Š	äq¿í9!}3¥¤‘=êfW÷¸‚œÄIœ|Ü‡ÙrîÃ1¡ŽœÄ,Ž	¾øø1_›kð,N¡­hÅyñkh¯'ÄJï…È¯"J±hù‡àÿãþÎŸn ´ƒÛ­lÄ$&Án¤±ûÁ öb;v¢Yã.ØÑ)ŒÂ‡!ìÂø_+Ð…&4¢×Á«ÅjôàEì@ü¸mèÆfxC?ÁÏ1z5™)òD–ã?©N`N¾¤û;}
-‚ü)QuP™R¶Yºåf‹Ç¬XK³4Kw(ý´]i0‰ÎÊä+µpÁv¹ê²õ²PP,À‘|¯âU$J¿¼÷%HÀ`ÁG®íÎ°Äµž,4ñçÌz
-¼kÑrDN\›Þ³2ÀUÓtM)½4¤Ô™”ªà²ü0“?^ ¼nšQ08àÿJ
-2†
+xœûÿþ  è÷
 endstream
 endobj
-
-138 0 obj
-<<
-  /Type /Font
-  /Subtype /Type0
-  /BaseFont /GGKAVN+iAWriterQuattroS-Regular
-  /Encoding /Identity-H
-  /DescendantFonts [139 0 R]
-  /ToUnicode 142 0 R
->>
+142 0 obj
+<</Length 569/Type/CMap/Filter/FlateDecode/WMode 0>>
+stream
+xœm”Ioâ@Fïþ5KäÀØîö’ „Äf‰C…hælÜc	·-/þýÈýI4š ×UíªWtÛÿñvœ¯Msâ¹þÒ;÷ÍØ•<ß>­çû»¦k¶Ã³asöj»¦ìy íaw°ÕàùþÁ–×Ñð=ç)¾Tö+aªAÛ±šÚóýj¸ò‚fX ×Û¡n>x¾ÿ‹»¾jì‚"Ï÷÷Öl›zj®÷©AÁ[×”Gè\YÓI%:Mu½H‘©ÊAÈ}—uÑºÍÇ[?p}°ç†4²ÌØJ&QðÎ—ªºÍ\cdøŒÈkg¸«ì…f÷f¿cÛ^yj’B·ÊÖ¸ß`’)j¦@„?WÅ’¢¯¥[Ëò€à÷scî¡Å²1Ü·EÉ]a/ì-Ã0W´Ìó<_Mÿ‰'²ít.ÿKV´ÃX¯)Ð¤A(v¤BPâ(y¥Ž´e É|¥ 'G™Ô[ƒ$sã(ÍA[ô²C¦TØ#öÊAè%š†i‚_Šzü²¿L2á§%&~²~é¿½DðË¶ ø%òLø)‰Á/Ã<#ñÛ€ÄOÄOö‰:Sâà—aº
+~)*(ø)LPÁ/–}ðS0Rð‹å)ðS˜®‚ŸBg
+~1þ#¿“PðÓkü”t?¹(øÅBðS˜„†ŸFu¿F~ÕµœÏ;êr¦§C?ÝíÏ[VŽ]ÇvpWÛ]©éþT–?ßmÓN»ÜÇ½\îï©‰^ó¿’RR
+endstream
 endobj
-
-139 0 obj
-<<
-  /Type /Font
-  /Subtype /CIDFontType2
-  /BaseFont /GGKAVN+iAWriterQuattroS-Regular
-  /CIDSystemInfo <<
-    /Registry (Adobe)
-    /Ordering (Identity)
-    /Supplement 0
-  >>
-  /FontDescriptor 141 0 R
-  /DW 0
-  /CIDToGIDMap /Identity
-  /W [0 2 600 3 4 450 5 6 600 7 7 450 8 10 600 11 11 300 12 12 600 13 13 450 14 16 600 17 17 300 18 22 600 23 23 900 24 35 600 36 36 900 37 55 600 56 56 900 57 60 600 61 61 900 62 64 600 65 66 300 67 69 600 70 70 900]
->>
+143 0 obj
+<</Length 7358/Filter/FlateDecode>>
+stream
+xœ­zpÇ™æ×=ƒ‚$  )ˆÒ€€$0à> )‰Q¢d²,"©‡%QŠ$ëa¯­-[í8vÂuâK*N\¹MâÍ*J±eæåõÖií\víÛrÝ&{kWöÎ·gïm®R·º‹ËgW=Ò¤,{³uGÐÿtÓý÷ÿî&A ”â4Oœ:)Ûw5>àÇ þjß±ýG¾­| O åÎý‡Ïî;úFßS@Å·ê7Lå&×þÍ'D˜ÊIÿD¿4|€÷À‘“gÎýŸrhxÀ/È½x“}|Àô‘Ü™cÂãÖ€` y:wd*‰‹@0Ð÷Ž=qRúÉ4Ê ž<v|êØÌúIhd þÿúŸgñ,¦1Mç*1zsáµ.ÜZˆ­{—–-þ–Vkã‡pÃ¦7ÉÿÜÿx¶wµùTt¢ÇàC:°kÈç rzáÃ;ûé<ÙD_!I€A•v¤û2²<xå[™4¶3ÍÚÜ¬>“Ý'ÏìH3êË½l‚	Ê^·ÇÃaH*©9$³‰#*“³ûBŒªŠGñ„˜ Ê“×‡‰$³'ål6‘§Žd"ï’Œ&·Ÿ‘™Ea4™ÌM2qôÌ¥4™M0ÏÔï+w’Ä™Ñ¤’˜³{2›PFÓS™¹JÂ‘!&ªL2g2Í×c•Édà–'eöÊ(ý;çêIY²o¢I}i|™m÷¦=ŠÇ=“–ÙèhÚÃâ·ÌbœŠe2r^Gç&YýhÚS|’Y3oæÈWFÓò>yf&'3óh:ë–™ÌÇÌœŠr*šug3™Œ›Q³$'¶¥9ØÃ,I÷ [Ë©µƒ¹VLpÄöf2“¹#ÁL¦¸ƒŒ<É*“J"bUî“™èËMÊÌ˜M3£’`&%áöx2ŒdCLÒÄÍ„ <™7îMÈ|o×­³Ï¿™”í›`†€Gf¦¤<#Ï0Ì7|LôoMgGÝ¹m™´’ñddK3ts¹Y	1£ÊJ’Á9P]Í&••(	EfP9F÷îcd‚‘,3B¬D•9·åÉ‰"öÊ|Ïf8$›Ò¸5«s%åHö%ž%Ã)UW’EŸ…†$}Y¹oFÉq¥jÂ†›+„Én_|J.¥/Qö)¯3ïhš¿¿ÛKåÜþ•Äµ2„¾Ñ´Ç­x2OˆU¨yJûØd.bV•‘¬,³Šäf>Ì*”D†YùÓ¶´Ì¬š¾lªÌ¬šPä"&f”³%³òLVf6%¡„Ø*up{:/N¦2^V6¥œ	1»:¸5=8¦wº=/³ký5UÉéüªUIFr	fr—cÔ—ÈWð/+õ%©Td&øFÓy.>&ú332_Öð(Œäi·>Î_¡>­'Ã*’ÌšÈ2ºRYŸ¢Â<`WRŒ$zç!š¶œ*ò }ÛÓl•’ûX¹’`e
+“²	™9”„œe$÷RUv$	.	G2ËÇòS=t×fB¬RÍÃ1—š'¼­Ró”·Õj^àíj5/òÖ­æ¼]£æ%ÞÖ¨y#o×ªyo×©ùÞUeQLÊnO+r##÷q·	1uÙ`åÒàçôÁÐ²AÿÒàq}PVÁ*‚Ÿ¶a¾×ê{å]¾?š‡±Z5Ox«¨yÊ[¯šxëSó"oýjÞÀÛ:5/ñ¶^ÍyÛ æM¼¨ùÞ6ªr·f¹MªœeUY9©0’åÆ‘ãÞØÈ·YeMAÖ±U–äOQ«’‹)<Â&ÂÍwßº¨ë|¹ÔÇMµòâìK7g´]†—‰çÓ0mªÑ8¨(bú>¹&#Á»òÂûQy]K©©^%–o#N¾×¨*wËŸÂ?C2±vµÑÕb±	ÊHr"bjž¢Ò'7Ê<60êÛ433 (99½×ÍÃ¯’˜‹âtB¬Se¨d.%ÁD},oA‚•&ƒS3Š,wÏÄB¬k%LnÔçc’’XDË,ËƒK|kúš(d÷5ÑoXIðkNÊ3Šö†ÒŸeRòN¿Íò°§§'1™T˜!™›M31™s3C2ËCÞïäYf¢_éÏÅÜ
+3'ûyê2'µU²òÝQôà*%³\_Ž>1+ýœ	gBðe'‹!õãµ2!Ö½(Y–™Á_”…Ò±ž¥!fÖÆû•¾(×bï’ùftI3lO7ÊÝŠGK¼ÅN™óUT“|ÌàÛ´¼ˆÑ•x7k/jKá&¿~'ÉEuey¥sç–UW¹‘K±Ÿ¹’éQ÷¶LZîÎ4æ›‰#bVŒns®MÜõÝÏz#©²Îàg-˜RYWpF–»¹ÍÄ>Ê¤d#k†XŸ¶enŸ~]ò9fQúÖ¹*r·Ü¨ÄŠó÷«y³èK,¾ò¯4éÿ_VÌ÷ÄãX·s{–Ù‹'Säs@Í£3¸(•j]A×g´¸›%lRœºÛÏ{¸½‘E!¶ùSúÕ<ˆÃÎÚ!6¤²Ž@ˆs)ö)r£Ü?£ä¥5¢rƒfÃÁÛ¢ÎýÁUç@8±U#ZÏ6uŽh=c3±íÃ‰Ã‰{8†ãê5 É`ˆ¥Õk¼†
+†XF½Fô¾ê5¢÷ÝËq„S»8N£îã8ÚÍqµ‡¯Ù±,_“9¾&'öò591Á1ƒ!6É1œ˜âNìãNì×øJCì€Æ§j|qê~/NÒøâÔa/NÑøâÔ´Æ§Žªyt/)ð˜öÄâÁûœNn†Øq.tí)±jž1'u’cÐ0¤ˆ9¥æÑ³4ëiíI{ãŒNò7Îê$‡?¨æIðNrÀè$œSóè]šï¼ö¤Á?¯“~A'9üÕ<)ÖIxD'9à¢šÇú¥ùÕž4øc:Éá—t’Ã/«yR\ÑI˜ÑIx\+ÕJ\&¹çD*ô¥Û“É$‚Ì4Åïè™Ådâ)–BhL°@€q?ï@÷‹D D‰ = Ù"Š¢Q4®²YRuÐî±y|6M¦U·ß#×L°|tk’¦nÿ hX¸EÃô&ªÐV:MF‘2B°i”
+9>õfa@\>¯×`®Vú#mÑp«Ëè÷+µ’Óé¨·FÛ]’2wåÊÌëO”5·tE"]-ÍeO4¾n™ÿÁæ_¯uîp|Wg¬öu¾v@Ýt¥PâülO÷ˆ„Òä0dÜÖÈˆÿX%óš ]±)¶°=lÛ”×J/\®ôÂuòf¡™ÎšÉ›·û¹Œ”…[ÔCoBÆç^,³PI CƒÌ1šæâ‰r¢dØA 9Pºi¢HrFBÈf2âŽ Ñ(Âx7 Ñ˜ÒÑÐÀ™x©Íf÷y½µV“ymÐ§H’R{7¹D"J$lSÈ×JìÃÝûŽ\|ìß5=QÞØÔÞími;}û±‰–Þ}÷ú^¯vß›>¾3×Õ¾¿ð8ßÐí‹22ˆ@A†(Ã¡4E¹VJQê\%š«‚áˆv¹ÂííaÁù÷ogsÔÝü­·Gþüù+Wž/ôüN—‘ Az«Q÷–Y¨ è*_Ü¥ `©òÖ[Eóê ÇiF#‘6¿Rk¬‹FÃ­••N‡$,˜ÿ®³¥M_óHõÅƒG:šGz%£W^jÝXg6îmÝ2ÝÓÓ¾k¸i?¸nÑz¥¨†‚žx'D1¢á (-Úœ‘[rNÒ²zµÅ¬VV×®«±T[ªì6”Âì-1»Ms¢,r§KÜ‰´…[N‡òü¥K33—.ÍÄc±8ÿôöööjÖÈ?§îxü^íëFsesse³ægþ…[´ƒÎÃ¢ñ°…û×‘÷ó ?,Q¤9¡t3©ªª|UÞu5p¡Òï2š«‚•~Î[´=,IF×ÇòºƒÍ·Ï¬ß|"ñÆžr”TnîíÜMœÙ‰uDÂ±ˆ%unû®ï<¬N|}ÐÔØ0p´÷Ž¶ò¶öX¸¼­ƒë±eá­¤VøÐoqJœ¥D€0Ä[n¥CÃ –{°^o°èÁuíšq¶ùëêü+ÍÖQéri,+ÿá‚<ŸP[×yÆ†2çŽ~9µ¹jss@]çÙ6œ9ÜÒî_ãvØe–þ¾­»¶lwËîjgñq··ºb´…Z±
+2&ãfJDTj EÏ\QDŽÛtÿ°DÍ7s3Ü(Œ¸µÈÐ¿äuCŸ„dâåv»]¶¯ó;¼^«ÑìÚÃÎ°&t¾ZbS°Bð]³Fç¦®ÌÁƒ™®MNã,ñµ··¢Ñ w·Æ.]ºt)ÖZø[ÒÔöÔ×}µ®^Û•MÔªÙ®oX4Ø¡aƒf°¢n°Ü\—ªô™†zmfæìÙ™™³­±X+ÿXž>wîiþ™îíØÖÑ«}i>»A‹•V80ôCXkvî­EáDªEwÜ¥ËŒs¥Élq$/à€C±{m’yu0l[•M±é|Ù6ÌJöÁÎ¡]³jÐ¥âîæÎ}»
+s¤³%\¯þT! ù7TD<ñµ””p“[ä‚FìE‹š:Âa§6¹20kô]°F:g©ø¥/]^ßR¸µ´¿wáà1‰êô-ÛÏ):bWì^«AS²íœ++XŸ¥ï^½“ù…Î;þ¾‘…ƒšfÛ´ïÖ…[Ô¯É¸ñx•Pb#¥CA¨Hö‰ÁPT¹–%Ý«œNÀYã\Sí‚œ?ÓÇù±Òéôh9 Ý%I
+•œÎ0WÿüåK'O<Vx.Þ¹-:ê™éîx³½ÙòäùÏ?ý…³jI¸;>ÞÐJæºZM¦Ö.MÞÝ·è:jEõ]ót‘Ÿ½¼UÿBž–”¿xüñ³_ë>^ÑT×‹µÕ‡W«™³<uþÜÓç{=¾®ðö¶NŸïJjë ò5:»Vyˆ"”
+{¸é÷óC²XJØvO­Ñ\ô9*5­ûµô	;ÃN…Ô:ÊÇŽŒNNÎž=ûGåŽ[SxñÅZ=°p‹º¨¶iÆýCP2äþ!ˆHÉPF·øU!¤Ÿo{ElÆˆ;^YìÅ”>m ó’Í®Øn.‹ÉÙ¶é)™×ä‘åæ2«Y:)ÜäÆBÆn¤Ç¯j€öÐy˜QŽH¼U T"CB‘b?$‰×]$9l$¢˜G€ò2K)Ì0Ûl«l&ž?#žá¾¦8}|Ù±ÂMRy}çÎÂþ¬ä±äz!~ò±‰ënQ•ÞDé•„×'cú¦;czü¾ o)¦ßÔ+uåÔ%åÆ}÷6G:‚áM;ÓO<èß±f¤qJmÛ´cWÏÙ–Žp¶¡¡9äó›,G'µ¨{äÚ1ÅWRV1¹5±¿“ë«ÖSžÇ·¼XB©¸”œ<?"G	å¦i4P-¸ãÕZXâƒ$G	wêÅ±L¼Ô^kWì>¯VI-p×']ÜÖ¦·}³RÅ@{tÈ&TŒwmU|ÞðìF¥m––eÛ£mÝG&
+/‘žpK½¯ð}Ò3É›b>ºE[è»Z>:­sÌ“Ñ“’{ñA0ÐE›[£Ç¢;r/À6ÓbŠZ>ÌÃß²<Eïš¢l+S”Sñþ~)êÝÂ«‹9j÷þeŠà7§È!úDYÕh:náBÖj¹>^ÙÚÀãÅ8wÖ=”-™¸™››`v]¶°í7çg„‡?:¯ù|»VKÏÃÉc¼(Pnâ\€{õMpÂéuhaÆnshv§ù·°Z¿?bûKKC Ð`y¦þþ‰‰ûëé|¡¿­[QºÛÈ|aç¾‡Ö¯hùc=Ÿ¼°p|W! *î\Æ'8›6+5WÛÃ‚ò_~zeújáGú;-€°–ÁÉs†ÕDµÚØ [ÙÇÕ±N§ÍéäéÎ®ÇÅY©«SŒFEx%ìÝ—z‚¢7|åé¯Å}‚7þÕ/Ó²·¾ùÍ·øçö?¿sùò;üzž¢ï¢Þ¸§Ôl¤zÖôÏ#PqYû*G1õÙøRF»Rgt*f}‡_xímöLÏM»¶žøEáµw[ø‘Ü¾£}T„µñu¥”oEÐs)¥ZlÝH–*	’¤(‘pk{»^ð“«_ùg×H|_¶¦¤òÍç›L!*Þþ^Wç‰Õ½”üê™gkâ¢ïÂÌõ	BúôPÉ—Ia„ Ä(
+0³h®†k‹‘2ì|ëË³6«ç)ºý6³ÚN€¢ná­¹ÃÊˆH@ ûþ°Â(½Ó£·|Çð’ÿhÉÇñ%ÿ±9¼
+÷Ÿåg­J—v(ô¯ðre…ÿÌF£Ñ@K{{ËRGzo¯Ù¯¹ŽæD¼
+X¸E»©„ðd¼ÜIÑAøéÈhŠ‘M…d ?Š9ˆâÐ08›ÄDÔp	1øÆîßc"‹è’îÚZ‚ÚP­Zç“×V»VYËJM<Äc6W=<DwÖ*ˆZ©xÓvvòè±´÷ÿÖØ!Ê¶wí|oLmU»\[ÝÇÇr”»
+m[Ô¦os°5²mãs«›k×mllŸÈ¾Rî8´£Né]·Öáæán-ï‰(ÑüŸ,ž<—ûV	Jœ6íä¹tð|ëå¯'[L-Ég^¦âÛßÿþÛ<‹r›Qiµbøi1‘Wƒ`!T’¡"¹µNqegÑ†<0ô¤74l$’¤ÅÖ÷:-Û`Ä=È”ÑtÜQìçrrøp\1	”Hôà/,Ce2ñŠššš@Mƒßáõ+µ&óš GìâÑ)²Ò#aºÂiÍ£f6n	uu®°ÆŸqÝÉÏîŽtµïÇ9þ‘XëîÂ¹úºóÜ$#Ñ^®ƒ7 rsP¯\
+ç)Œ,‹Û>§!—_ž››Óë@Çè<Œ(…?®ð;"â øÝŠ‡ñJÍ0Âh³Ù$suÐS§{ØN!L®©?~õ'oý¤ð+Sê©ï~—Îßî§…4›xÿH~AÎ@ÀÚ¸ûùdSíó	ÿÇ'ŸÔÞè::­~¤D*ìGq;ÉaÃbåÄ-Š—úáÄãÔ~m£äÂ_ªÂ{tþ¡o>Tø;Ý>¯.œ¢«è°"¤ç»R,OwÖ;ÓHæºËÎÉ*ý`Î5äRiäjlwçìäÅ‹“³»cä®Îûþúô¾ÓÝœ¹ºý§È+×Ñç$}ÜŽ¬  /®M°´ŽW’ŒÅó^]x-u’–/ô«;Ö¡+îF–/7ý?œ/¯?zÚÚzøgéêãì½™³™;3fvj63Ð^:2¸Ðo*!‚H†$"B€(ì‡ÁP,q©ž,*Ê+å®
+—­Òc5rU)6¶¾Ñ®J;÷Œ6¿¢8=KÊ÷ÛÐyåÛôÝÓ´ÝCçOïß|ÈZxŸ'ë×6Öÿ\;“ivN¨…£ö=†’<!7È‹¹a­]ø"	AÈðCE(4x•µ®J‡ÝVn”DVž‹Wj}Ý:®—ŸWÆ®ˆ^·GÂN^×9õ‚ØèTh¥+"9WùëœÑÈíMÇ½ã=;\»wÌ?™¸'×Én¯ÿ¿{üf©=´gCÙÑvpËöCeTeË¿#®Ú7¼ý¤í0®5¥tCá·JÉ¿µnÔm5°p‹¶ÓyÈèŠÇÖÖØ¬¢hàç7j Äp;­Hü0*í$%y2öB+ðí>¯¿Öfå'*â1êU£^Åó(¤‡!ýbÎî¡e…ŸXKª6÷tæ:ãíø“mGÜÉp{gWkR}h5ÉÓö·#‘©ÔÀ±õÝÓØÖÝfj‰µØÿg¯¢–kwMZ¢»ÃG!Š†=<+§ÅKGír–gã%Ouzœ£ä§…_’µ…ÿLê5oýÞC|î^ôÒÕÔ‹RÝ²‰Ž„—	‚ý T›™¶Ü1qûÇ'Gç?]½záêÕÞ§nÜ8uƒÛƒwám£7Qƒ :ŠopJTÈ‘‚¸ìJÑD†¥+EU]»P;ÔX¸empmÀ§ kBú•¢núõ]QÐFgQÞ«VøÖÊ§¿=½~0wLMwÄ£ñÁõ§·µD¢ÍÍÑHK8ÖÞÆïí,m÷um¸ÇfrŒvFÇššÆ¢£“íž]÷µ‘ï„ê+êB¡ºŠúPáÍŽ@SSÀÑÐ… á‰Å:ÜV"üúG;\%‡y>L	#¼ÀÕnE„°Ýn·¿E¨SŒ‚búJÂ'¨Ã<|É§žÿÓt­ ¤¯ÒùBþÕWÉýûv?yðÙgé9„ßÍWÐ›pÁñ^K)©$è Á Í2Š7Æü^DÜÃß¢~ê®r¯®†.ŸÏÆ/CÚ#KaiÙõ±Ñér*‘7GÇšüuQóƒŽãÙþC]û‡ª^~ÿY¡%Z^W×XNíj»¯{ëýeÛyv#8tVÈñ«Yä§N.›Š…¬Ín«Ôªd£±®®øG{Ø¦Øè¹ðåG#Â¿õ'ô{Ï‘ü|ßïþ÷t¡‰Î^&·ûÉÏùü¼”ÿ5åaÏÎ¯¿õkíÂ§š¥âí@ð$çèûP——&Sñ5<	‚Œ/¦i‚å	1/!Ex¦>÷}ÿßàI8sà‹göTtÿ/…÷¸èÿ£å©_òönZ7ú?ŸÏƒÀÈ±ÚáÈ(üY¡¿ð—âóÚLË¢4™¦Ñ@Óè¡i(äU€¦!Ò4ü4w±m¡itqÈ«ÐZUk[iÝäUŠsTÓ4Ö	ÑW|ç74všÆÂEmž4;Qµ¶Ž¦ÑV\‡ÓoÐ44'h£4«4þâøPq|-Mkkññ^š†W¸¸ð_[¸ˆSDÕpï à ¾„ñ!ñ’½ä:5Ñ]ôZú…iáÛ
+b¯xLü±ø?ß–¬RLš–.K¯JÿÃ(SFfŠ™v›>,q”$Jv—\.ùqÉoÍæióó;¥Í¥»K/—~d‰Z¶ÌY^³pmpÉFñïQ‹@qøñ€¼Wî„Àë,”bˆXà¸¦mNó¿±/Ò&|µHˆã›EZD3~]¤XM¬EZB€Š´	Q²½H—à)²¸V)jéê"mA-íFGqgq±p2ZÑŒ´CÆ&$0YCÇ14BFÓ˜„ŒƒØ !¦1¡õoÀa†¼l¦ÚÓN`
+Çq
+S˜Dcñ½qwR‘± ‡“8‰ã8
+cHà(c­hD³öÛ…Ä8FÐ¥Í±|†•ï!´ôþï·š¼„¿GÃœÀAÅ´&‹Åõÿ5¹Löi;¢!çÚ€ã˜ÀâE	-JpqSn/öâ ¦q*dŒ"‡4ÙžÒ¤/c²¸“!ä´uSK{\DnÃQœÐø8Œ©"rã ¦ŽÜ†)Ôøâã'´øÚ\ƒ'qhBNk¿ºö1­­ôiˆÜ¢{þ
+“wýê( ?ZÀí¶NØQ{0†mØªi{Ñq¤áB£èÃÄPÁ.lÁ RÈ`3lðÂŠ”Â‚VDP#ªPr¸Ñ‰Z4ãoÀ‹ÿÁxm[:OÈ“Fôÿ":–‡1ñ0ÔÓæ•àOñò=Ò˜´ÁÔ!6˜ÜFÉ\ìœ¢ºIê¡-R­Aë,Kü¬
+NX/”_0_0JyØ?Ã+xñâ/ï}Ê{Éå­i¿œæÏ“©|=¾a‚ÞTÆ¯ã]ó¦ büòÄöÅþ/Ÿ ã4)uÑ TcÊ7ÈÂ£LüBž"uÍ0)!•ð8å
+£
+endstream
 endobj
-
-140 0 obj
-<<
-  /Length 13
-  /Filter /FlateDecode
->>
+144 0 obj
+<</Length 13/Filter/FlateDecode>>
 stream
 xœûÿ
-~  6Ì	ð
+  6”	¸
 endstream
 endobj
-
-141 0 obj
-<<
-  /Type /FontDescriptor
-  /FontName /GGKAVN+iAWriterQuattroS-Regular
-  /Flags 131076
-  /FontBBox [-38 -212 876 811]
-  /ItalicAngle 0
-  /Ascent 780
-  /Descent -220
-  /CapHeight 698
-  /StemV 95.4
-  /CIDSet 140 0 R
-  /FontFile2 143 0 R
->>
-endobj
-
-142 0 obj
-<<
-  /Length 1586
-  /Type /CMap
-  /WMode 0
->>
-stream
-%!PS-Adobe-3.0 Resource-CMap
-%%DocumentNeededResources: procset CIDInit
-%%IncludeResource: procset CIDInit
-%%BeginResource: CMap Custom
-%%Title: (Custom Adobe Identity 0)
-%%Version: 1
-%%EndComments
-/CIDInit /ProcSet findresource begin
-12 dict begin
-begincmap
-/CIDSystemInfo 3 dict dup begin
-    /Registry (Adobe) def
-    /Ordering (Identity) def
-    /Supplement 0 def
-end def
-/CMapName /Custom def
-/CMapVersion 1 def
-/CMapType 0 def
-/WMode 0 def
-1 begincodespacerange
-<0000> <FFFF>
-endcodespacerange
-70 beginbfchar
-<0001> <0050>
-<0002> <0075>
-<0003> <0074>
-<0004> <0020>
-<0005> <0079>
-<0006> <006F>
-<0007> <0072>
-<0008> <0067>
-<0009> <0061>
-<000A> <006E>
-<000B> <0069>
-<000C> <007A>
-<000D> <0066>
-<000E> <0068>
-<000F> <0065>
-<0010> <0063>
-<0011> <006C>
-<0012> <0064>
-<0013> <002D>
-<0014> <0076>
-<0015> <0073>
-<0016> <0070>
-<0017> <006D>
-<0018> <0032>
-<0019> <0030>
-<001A> <0036>
-<001B> <002E>
-<001C> <004F>
-<001D> <006B>
-<001E> <002C>
-<001F> <0054>
-<0020> <0043>
-<0021> <004E>
-<0022> <0047>
-<0023> <0046>
-<0024> <0077>
-<0025> <0052>
-<0026> <0045>
-<0027> <0035>
-<0028> <0031>
-<0029> <0028>
-<002A> <0029>
-<002B> <0033>
-<002C> <0062>
-<002D> <0055>
-<002E> <004B>
-<002F> <004A>
-<0030> <0053>
-<0031> <0078>
-<0032> <004C>
-<0033> <0034>
-<0034> <0041>
-<0035> <0042>
-<0036> <0044>
-<0037> <0059>
-<0038> <0057>
-<0039> <2013>
-<003A> <0039>
-<003B> <005A>
-<003C> <00FC>
-<003D> <004D>
-<003E> <2019>
-<003F> <201C>
-<0040> <201D>
-<0041> <0049>
-<0042> <006A>
-<0043> <003A>
-<0044> <0024>
-<0045> <007C>
-<0046> <0040>
-endbfchar
-endcmap
-CMapName currentdict /CMap defineresource pop
-end
-end
-%%EndResource
-%%EOF
-endstream
-endobj
-
-143 0 obj
-<<
-  /Length 8738
-  /Filter /FlateDecode
->>
-stream
-xœ­{	tÇ™æWÕƒà…&’"-5ØH’"’â!¸x“ DJ€,‰€Dê¤dY’eY>ä3cÓqœu’ÉÄÎ&û&—7{
-òÍöÄ‰“LÎÍf=Ù¼ìNòžv’I2™É>Ù›d,p_U¥X¶óÞˆ"êïª¿ªþúÿ¿þ«A ¥¸Ú÷Ÿ9­*·øïð% _9pâà±Ot¹;€
-×ÁÅÛ,9Ã÷•´§-dçíÇ£oÁ€®C‡²‰þÞ ñÐ±Ógÿöï×=ÿ@:oÚŸ½5qOèü€Ëž=!ýµý t€z<{l!þèÂ/€Ð	'n:uús¿ªWžøÖ‰“'nÿO›wø9þü³˜EqºPXé¡¯­\¢ö•K+=W]\3úo…ñ8â!D_#{øïuñ/ðÃs|r3@n]ùcñ™.“ú
-‰ºÊ0›Š§UuìETL1óö])ÖYÇšÓ™êÒlŠQoö%+¬Ø¿_ÛWçñ0¤¢Zì¢™H€©™FuÍ£yLÒÕùg$§‘(sDÕL&’£Îh$ç•¢ŒFgÎª¬Lc4ÍÎ39yö¥4š‰0ÏB½‡÷^¨p‘H½ÊhT‹\pG4Ñ’©…ô7á˜&ëLò3W4Å÷cîh´€P§Î«ì•$“}».4“òh|œ™ã)“¼ém7¦<š§n)¥²d2åaátÊz8Ô“N«9;;Ïš“)OáIeí|¼c¾’L©Ô¥¥¬ÊlÉT¦Ne*³q¨‹C]™ºL:®cÔËÊ¢û¶¥Æ8²‡•EëÆØz­Ë¾hÇ~Žñ¢	ûÒéùlš:]8AZgî¨I˜IWã*“½Ùy•Y¢É³hfÕ"uOš‘L€™»™äWçs–}•òãÖäóOfÎÄ÷3S‹GeÖ¨º¤.1âÏµ›¼LöM§2Éºì¶tJK{Ò*oO1â¯ã|)`•Dý@1[uV¢E4•A‹dÝw€‘ýŒd˜¥%ÀJt•S[Ýÿ¢Œ}*_…3iŽ’‰	jmú…’
-Dã‘Ïªâ”êW+R™±
-ñkQ&{3j|IËr¡
-f£Ž„©u,¼Ê0&yµlÌØ¢ü:ÓYc2Å'‡ßnR×-òLy¤x2å©Ó<éO€Uê9Jãl>0»ÎHFUYet”/ ²J-’fvþ´-¥2»—¢«Ì.˜¢¾(cÿ’–eJ4£.eT¦h-Àªô±™TNž¥Yù‚v6ÀúØtjl»ÑYçI72‡èwê9TEgS¹ªª(#ÙSüüÊ1êä*ù‡z#Œ¸5•IÞd*ÇÙÇdodiIåÛÚ[<#Ù"\gŒó)Ô+zÒ¬2:ÄìÑ¡£Wë:"Ì-ÆH”aËBˆ–KG4>“bUZD³
--ÂÊ5fÎDTæÔ"j†‘ì55
-ˆD"œÎh†åœV?{Ø_×0·žƒË`ÕzŽð¶FÏQÞÖê9‰·ëôœÌÛ:=gâm½ž3óö=gáíz=gåí=WÂ[¿®ÁÌ™±™”¦¶2²‡_› Ó×ºWo6k}«ƒ'AU«ô_ïÀü¬Ïgå]{>žƒê°=Gx«é9ÊÛF='ñÖ«çdÞúôœ‰·MzÎÌÛf=gáíF=gåm‹ž+ám«®öÍmÓÕ«É¨Q‘WŽ,¿­\yÛuÖægm-¶IWÕ!õ:bÕ²=·ðïˆQÇOßQ”u®ÂçªÇ6µäLÄOµ§Å)ƒkØs=œN]	ÊC:
-8ñ?Ý“ÿÛÒÂûá~V¸ÐØ­'×I\ü¬]ºÚ¯]‡~†h¶'ÀºõÖêþ ëy7TF¢û{l³ž£p{ÕVuˆÛF½#KKCÚ–USûê¸ùÕ"zq9[¬Wgp³j-Âd/“½-W†+ú–Z5Uí_ê	°¾«ÑÔVc=fÖ"El•e¸q	O§ž‘U“Z÷Œì3­KG¸ÉµEÕ%MÌÐfŽ^{o3ÜìîIŽfæ5fŠfç“)&G³uÌÍp“wíœ¬¦ªLöi‰lOÆlÑw]¶¨Ø%£¾Ý&ša\ÍÑ†É›e¦?Y•É>N„—!y3ó“ze¯t€õy¡ª*3ù
-¼Ðú{l`uˆÙÄxBâ›r)nYe!?ŒÁi†™T«Ú¯y„ã-tªœ®‚(˜ÙËLÞ‘µAŒ!Ä·Óö‚´4®ò[×P-Š+Ã#k\qX×ÔVÎÅ«Ž¦’uÛÒ)µ?Ýšk'N€^5º­.yÕhämç¾ÓŒ¨Îzýï´aLg}þ%Uíç:¶Ôs}TfŽ¶²v€ÅÅ‘¹~úÎgY™1ŽÎTSûÕV­§°~BÏÙdo¤8åÏTé¡ÿ(-ægâv¬_ë©ó¬ÑOº@çžC¯¿È•a=‡>¿‡ËŒZ8Í*Ft—qí/€ßpG+ëj	°Ñëôé9§ƒu·Ø¸Î6·Øçb\S[ÕÄ’–-rkRç
-Í&ü6¥_ þ Kê@80­_ ¢g›~ˆžígÈ`3‡³‡;8vêÏ ˆú,¥?Ãc(€¥õgˆÑ·K†}7r<Â¡ÝO@{8ž€ör<Íñ=ãþ Ëð=9å{r`ß“û9Î°?Àæ98ptÅüvHÐÅ¡Ã‚.tqè¨ ‹C‹‚.tqè¸ ‹C7é9ô¯
-ð„xba€Ýl€ƒþ ;É™.ž"þ ;¥çHç´rœ[)àœÑsX]õVñ$fœ5@>ã6äèçô) Ün€áäwê9lY]ï.ñ$ÐÏ G¿Û 9ú=zŽî5@ŽpŸr„ûõ¶®®÷€xèï3@ŽþÈÑÔs¤€ðr„%äëJEˆËÌud*ÅSš§Î“NGüÌºÀ¤ÆäÙ¢³pK¡´G*ƒ6†}¼O=(‰i§L$‰ÌHdJ–e‹l©Rì&s­ßáQ<^Å£¨´æò/ÉOó©ì­KýôÃ—ùš» º.Ã'üáfH T"!Ë˜ãº<a"”Æè$à¬*/…¶FÙVã*Á·ËiÖ4E	vt…B>MÛ•Ï<˜ùü“¡¾¾Ð“tùÈÜÜ‘üÉÍ¡M›B Ø½r‰¼Ie8p×s ”q‘Ž…«$BHb”"+`“uc¬,™
-»#²3†Qu^gÞõ¦¤Óé‡æh0Ùêü^Í¬5øBJPqº9ñJPÑÈgåG¶e“[úCcÉäLæÐ2–5‘¶“—ß@°	  Ëp	îËrtÂL(•æLD’%Ë/™TEqz4‹í·Óí]ZƒÏR´P0t]ÚïÖoÞ\^65<q"ùÄ_h”ÆêÆÄ{þy^4Ah¥‡jT†‚†ð†ÊRJAÆ%ˆã’&“f—mëü$HÌfM;º»¥`uu°›ü÷ä
-›{Æo\okûÁ¶ò•/?ÜÖ«;Eþøã¯}Ë>²r‰º©•¸zxc‘[ãü@$+BFÉ¤ÝØo°×W»P‰
-ŸÙVíwû|¡Î®®`‡›«€Yë2äß`v¹œîàÅÃ›7Ÿñd2ÎË"ç¶m;1>ãÛ§G§·‹qÖ ù•QOx=%%ã‚bœW’bÒêQAW°K0ÔìR´I“ïÁÎ‰‘é$•ï½7¹mkþ¢E' vÔ¢	—ÂeîRj6™M”PZP8L&)Ë/Ìø„…˜Í4Jc D0`xUÿ¼åÄ„ÀÆ;";ßëªßûªáÎž…ë¢S®ÖépåºuëšÖù|ŽÆF­Áj«÷{f­¡©Ûì…Uïì
-vTCAz•¤ÈÎ=oëš}Lî8¶wqqï±9ùñññžøäd\9zn¨»çñ™GÎ{$3“÷t|¡£gfhth¦ ;>jÇzlÄÿ—V)”J”˜ÌEë 0›¨ù $IÎB–Çù	%V
-Ä&JˆÅR|XåöÆëÌ±’âqÁFI‘ãÞ&Æúœ«u6lØ¸¡¹±á†:·Ó^QZb–±ž¬·ÙÜ~OCS±Á `¨¥IÜÁÖ Ë×
-iÿuºÔÔxëtæ÷íÕ»\Fo<êªlüeòøÒæŽ™ÌÌÈ_{zÇ›õþ=Ó¿¯t%º»›g']M- Ø·¨<øœÄÍr·HRñv˜d*¡ÀÂj®Œ8ÉøÚaçõf^wçB9 šCSÌ¶uÜìóû×áv)šb(’²/yÅrR™[Îüsd€[ÎüãÀÊŠPèoÓ‹hÂðÊQØ	Å8 k„ÙYÈ/lÀ,wfTF	·DÜ¬‚p$îÐ/Íñ›“&” ¤J©2ÙjýÁñ„<.âqÍ’‰üWÈÇòÏäTl"ÿHŒ¯› ÈgèÅ‚Í–$qqâ&~³æ¸…KLÀlŽ™'¹ÅnTìÜf;¸æöM˜³‹[lE{úÐ¡àÜ”»zóæõ=”$¯Ä‚‰ñºXi ½3–‹3òºšÂT@|geÃ™rvÚ¹#r•k¹©­eg’^Ìç†RDW.Qµ£÷ºœ”ûRÈ T&-„ë´°ãœmY3‘¤Qi²¶¨m¨õ¬¯Gª5§Ïj«½Ê»<\];ºº«Ífòc{¸fÿæx_ÿÑDìÐæü½;†ƒã®¾šc£í‰fÒ<.‹œ›ž¾=:xrÄWOµù›»ÉO6ë–ÒØ,çÇÌÊ%*;Üö»]%VYÐY0qò¸TG…TkQãõ6r©ºƒå®¶øVmU‡ ëwÜql8S®ˆ´Å''‡öµl®™-{ìŽ;w74ë;©ÄÎ]MÝƒB{ü‘^„ûÁw£1L”XL2lÄ&ÛÜþ`!]Ï4’µÁV/ýO—o¯Mr‰ü^·vO?_
-j’‹W±^hd¹ `³`¾tU£^ƒÃZñªpæ×z÷eøu­Pe½rƒOq46X®D:†ùçaŽïjð_åŽcsGÎqÃŸ/Xþ™Ì£çÏ?š!—ëûz:–¹ÑOÍqÉÄL¾LvAÂúp¸,wŠkJ	™C#)’­Úïy\Obž™áóÂ ­¡2,\á×Û0CR1¾„‡"óØR
-:‚Ž ô‡—¦—Ÿz‰Êù­äïxF„î—Q;|†NQ"ÃŠ\Öê”^M7tª©Û-‚½N_SS+5Xbœpº««×SÌ~<ÝåÛÕ·u´Ý?½i´ëäÞû';»Žnj™î™/[hÛØÐ½ª¹ÌRÛ×96µ}Ó`Ksñq|s+=´žÚºRN¯ÒY._.7aŠF¹‡¥+º"LñU:p-žó]×z÷eÖêŠ£Q³s]1B+#ªohÒWéÊ\r®ÚÉÉxÏøx7øB[ò‰$ôDhŒÐ• 5R;ñèó%”J«œp™	'ŸÊÉ´˜¨0ìÔ
-Ú9ÉRÂ©_ƒà¼þìw˜ÈO[Ê®ÃÛh·ÚÖGÆhÖÚßU “”áî®'µOm™J'»{ƒ‰d×æàp’Ê3`g¨µÏ°ÌñD°-ÿ8HÄykÜ“A€ÖÒ×xn¬(§’d˜>!….‘_Å0éö6‹ÈÖã	u¯ÒÅpÂi¶X<´6ßúÏ=ÑðÀPÕXÍ±½NMM¼JnßñÃŽlGÙÖø–ÍõC{nºqôŽèçùÞzV.Q•¾\ØÀ=d+1I²ép1Ä™°ˆßl„øn·Õ
-¸7¸××ÕZ]Vge9,07”ðP_±;û5!¾/êv¸\N­çÒ¥KÓããÓüwË–-[ÊÈar8ÿÑüGGn;~òømâãÿ´»ÛÛÝí"‡¯\¢5tn4¢+´™{II&Ò‘prÒ,O;Gédu5PÝX­­¯‡.ŸÛb«1¼CWwÐl¶T_7	yùüØé-‹·ÝUoªß>00ê=šH$“CCÉäPÙ£wfŸ¾¯yç'OÓ¶P(;;Ü;4•°&¦Ä~EÜ	µa7×¤¢¨Ö˜7¯K‘Å{ï»ï>#7_Ëó5¹ÔÈÕ¹gó›¯Ë`ÎÖäØX’ÿ¾K…Žèzåh{JmjøWrðÀ¦`ZUÎBê¤»»ƒ‡&Y\Úá¤¼ëû^ÿ×ýßJó(#0û‰¿Ï¿FÊ¦¿hèïwVN‘{ñ $Ô„]kì<¸™WìÔVã÷%{NEÌÿZÌ©èVºlØxY¢„Ð9PXåžEQ¸9&Š¦h<rÛ1óÏÔGo¾ü(½ydÄØ;±r‰®£¯a·ñÕîkâ†‘kã†u¨}§¸Áh¾~þü];³†Ý[{yêÙ»Õ=¼!»³ì%Æ^Úžðt÷Þ¾xrñöÞnO‚§¤ HÔJ—QÊýœ”›Q®
-Ñ‰Bø 8”*ÁUMÑ” ç­¢}Ê2~ëo-ã·Ò©Ë9º|ù:r9"tÃF_ƒ/„K+Ê©‰‚Hr1SZdÉ$,:1Ã:dÍWoƒe6ÇÔ«Âˆw[ï½,Å¦MQ^o£¨bx5ójqwC!-ÄË'_29‡#'n¾ãÎôBÝ°{Kï¶éÑéÈä‡~>¹§}óO=»<ót÷ž;¶xâütd8šÿˆ¨=UÑe”ˆØœB’©t‹¹Xy’å˜\ˆ÷yIÅH@<.ñ£ì"/æ?Nùeº<òë‘ü«†Ü& ©›Êpr»[i¥4L2‘®Ž5œp:—‹¯èàõ’nQ5éJš¤Y,šôD(J'†¶LÑHhìCûÏÓàXöÃTþÆßúú×ßú÷×.¿E>ò™ã_ï(ÖÐ¼tå¨FG¸­„pOg&2$ÈÒA˜L"‹‰NPCs*+ÜÎŠêÊjÅí±[ø‘´B-ßL­»XLSžžÉg¦·_Øûù›®TÔfXó?$-C¢¦¶bœy×ª®¶‰”ø>B–Ms<ˆ™øÑKQÊ™©p—¿ÊM—Çµ‹<ÿ,™Ì_ »G/ðµGD®±ŒÃíê†*…šøé@ KD>À4“)ÊµÇˆ0è¤Óëõ5ÚÍ¶z?ñHÁ5&ºÁWÂŠ^Îá!oä¿é´ÔG:2]›G’›¶ª‰¾¡É©áÀæuCµäzsþŸ¯3‰îìjok›Œ[ã“ëo°‘»y ÅÙ7†}f“$ñ‹ºÊm)s%iäçv	Ûä
-kiêæÉìì7-lÓK÷½8BƒŸ=uùÑ|wåù-ý=ìð±šd*\Ê­Þû¸aå÷§„óår&ýlµƒ[Â*ÃñQ­µÒÐw{ööNï¹í¶=Ó½{{ÈGž^ò'^?·ãÜë	ÿÒÓ<)Á‘•3äá«÷ Áûx–BÄä «{4šÍ–‚“h
-®§.òðÚMþçÛíÑ¾r‰šékÐ–Ú(ˆ“˜ n ²IçæÀ$ÃtpMP"Ë¢Ä4*Mø7òºGE™Õè›ÛOÖÈ­(S‹ëmE«…HÅÐX¼/4T½uäáþ}=cáýÇ†gŽ4mÝ0:0’œßNwZºz[ýí'7&»Ã3•rÙ®ÑþÝA!ãøë–Ø°ˆ§/ÑúÕÜëšxZxºk‚\~ÇGWë!<~Û¤©¨««ñô;­õîË¼}<­¬§]Zã{‰§yÂ/ê™¾«Âiî“V.‰{îZõ¯Âµi à‚«Ñ)\¡Cá…çŽ.QÜ6ä)Ÿ®ìÝºµ·rÆ³wÏž½ºœß3½³£cç4ùTþæ›ï‹Fï»™<ŠÕzLDØ´áúR3‘þÄV9H,.M1BÉ¡‘òù™i÷÷ÞxkÙqægt9ÿáÓ¿Ïÿ$¿h¬;ºr‰üŒ.£ŠGI%VJŒìÍ¨îDWëŸ£"\¨B•ÃðìD¹ZÉ-D~Ö¹·ê°=Yº¹«wË[tùò¿÷¦Ú¶)m]Ñ(yªKV.Ñõô5x|‘—˜Öä‹#×æ‹^46ú½F,±6au‘0®fŒB®ÿí\ËÀÆÝ[Æ¦û“™™;Ž}r¬OÝ>04Þ7<öüÝ§Ë{;:7%¶vö”•ÛFöÎ¶è}›zËÊÕOfsú ZOeTÂÖÊm&"_IeÉ¨Ã¨De•Ë¨x9š
-¾ÊâÐš4ËÀ+_ÌLn‘û'vù«™ÇäGˆ9lÇŽc—óøö·Ap Õt&.GÃB3W<¡	&ÅÈºîÎÎ1ºÌí E@;Ä»¡
-îYÊ%Qg2ñÂdŠCÂÌš‹^ºL¼R”*…;5OÈ"ÜÀj.¯GÑÈ¹ü“¤õÜ¡CùO‘rù¡Qò‹¼3þÐ÷Èßpÿ¹ ½"n,E Ü@Làï 
-ñ£™ëzŒL¥¶k!Š´Øjýž&Í¢9‚¢IAòó¾7úv¾~Óëù7Kö}÷ß Ë—4›ÿ[#'JÞsÙ±<'²å^šÂ$S/	Ü¥…'ÜaÇÈd}]•¢yêëk«•uUëtÕj«ñ;
-îºhû<Ž¢Ùs]Rÿ’>ØÜ:¼iG(ÿÆÅ®¾¾®~¢op°ïtyß¶þQ»T1ïÙ"··5µmú§üWº:7vv]æü˜¨J—aE×Š+¤ñòa‘4[‰RYRe«jTMWHÒÖ„s¯ž?þü«/oÛ¹sÛQºÌžzŠœ>²xäôåƒ-
-tHÈV«%&"ÕŽßï¢nØ`sVqÝð(âµ’#()„þ.3?+qïïHyòùO’Ù|*ÿÛbü/-í“R"qg<.ÒtNºðÃ.Åå*T>kþKš$þ×¦Çzé`*3;(õOíxfÏaÙ³‡.çYþß‰‰$ó,ÿ‘Iòr‚ì&XAþÓ|ß~RJëÉì{«Iõ“Ÿ‘ÒÑQ‘‹ŠšÔk"më‘‹šˆÌƒr¸ÐÃdu5OD›}>a¸ãî¦‚i5ª¨.óU&žÖüIzüüg
-i(I_“„>zç±5i(÷ß mñ±/¬Y(-–
-IÕ•B•RU,!Êá´9o%çßG^ÏŸ&ÿyŒúFÆ.ÿ„×âw°?D¨ˆ]Ç.óÎ’"n‡Þh£”€Œ›M s\¸ø
-vØ‡¢8¹‡#Ij*ä?Ž ¢)ô³}Ÿûl_í¶{¿)ëÞmtü–üHûéËÏÑåüƒäìååÙ)þ‘|Ÿ|„^„GØ^ŒTãdÒH,	O,÷œŠÒ‹<³\YÁ4ù>ùô"0úNõè]¼÷ù>uˆÞ-¢w‹èåŽæºŠ>wå'+=øAáíÃ	ñöaèê·++FÆO+Ñ ®?ñù~”äy‘¼_ IèXy”6K~xÐŒ6l
-·ê~ocmË©TXÌ­ Ù@((É  <`Å¤G]o—l5~“p(ÕŠáKºCA—[¤RM.áJ,.º«Cf³¾&WWWˆTxzÀ;¬ÎÎ›Û;àÛZŸh_ÿüñ…-·÷FúÃ¤o ±5VZrsGë&1ÉöƒcÛ÷[0õt|-¦7L>½ó¨õ Þ\þs0ÿëÍe´DºÿIÉÊ2E	­FôY&îÊjˆk!.w÷gÒüaõ™” BJKÒ½oÝŠÁ•¿zé×Ð‡âc­ÉÔóž*j.!ãu°•ñô[Çßí•Ù¨Y"Ôj¦G`-%ü‹_(¼p™@I‰œåù^¢„Gd’©pà'˜L	cŠ“Z“©p;Lr‰l*¹ûÝw+Ì‡V§›™ÚÒxOóx¼çéï'èéŽööljÛØÔ¨m¸¡Úe¯(± ô•ÛÜ~ÓÓ`„¾&#“.öòw²…/!„:El!,‡xÍ«Ú—O>5—½pzÿ“gÓ­&ÙÕ§·OµµMµû{*åøºZ7%Þ±÷CÛ¦>¸ç_é;;;;o[X>wûËG¦ŸºïÄZ›[ôMû‡‡÷ojÑbùøê33­;Ùñ—7öí}lÛ AGë¹æŽP24 tDÜ›WÄ[ùÚ°”&Ö¾œv68$[­¿ÚYøÞˆ3_	ÎM™Ì›7¯OÖ^Q8ƒàMz„dè ¡)gž…ë¹ºì,×Öšéœ1Âëk™#ôGGŽ€¬ÞiÃ^ ~N‹.ì…•;?E[œ™á¯’ï“ÛÞÙ¶tEC÷¬Ú–ÑCäËô‡ðaxOž˜1ü©<ªr /®äYÈÏM€ Ä9Žó¿€¡ò*‚'±âÚœŽãÉ$•ßá6	Û?ºü‘¹Êþ7`‘~É™ñzÙÌÛ'Ž¿ž?³b’’9anA&ùd–?“K~H¬´ößMA¥)ì¢)ì&_Å&òU€¦¢)DÈWq‚¦ÐÏašÂ>¢#KS˜%_E‚?Ó¢4…¢coï	šB¸Ð?'ÝMa¦ÐSèÿU>LSøM¡–¦ÄZÉBÿ.é~AÓ®ÂïH–ïÒŽÐÚùºüYšÂ(M!@S )œ¥)4Ð6ÐR<Eº_ìÑ_ØŸÏß-Ý/pÿ‘¦0MS8Ft,}å'ú:hŠ”H÷c°Ð÷&§)¼JSøÑ…äZÁ+xo’f²H>Lô÷Òné¸ô¸ôY–Sò_É_2EL{M÷š~hN™_·8-û,ÏZ¾gµZ»¬IëiëóÖŸ–*y¬ä;¶2[¯mÉö¬íŸJkJÏ•¡¬«l_Ùãe¿*_WÞS¾Xþ‰òK¾ŠdÅû+ž¬ø}eCe r¡òÎÊ+?TùDåS•/Û½ö¥[Ù£Ü©|Hùåï”žÀ·Ñ€CàÅÆg‰ ä—.H<F)–øw³ä 'Å]á0'0Eþª KHà³XF~S€MXG
-°í¤¿ [ÑEp	>Hþº —¢và24ÐDqNà6œÄaÄ!œ†Š´cº¡bL@X'q­P‘ÅqÌCÅa
-ŒãØ/ú±ˆE¨kV:%žp
-8‰3XÀ<Zóv
-¼ÓbDÅ4nA§q'qTlÇ6,à nÁ"²8‰´¢]üôacØ‰Iô‰•Ö®sõ*Û¸f•÷¶³zÍ¬óã&Ü)ÒòçîÏyu@pò˜À+®8ˆ“ØC…uö8Wäìã(Þ>ìÃaÇQèP‘DV¬­âŒŠŠùÂ©Æ‘=Öa,¬ž·ˆ¹7á” cÌ),â°Çä´tññSb¾7—ìiœ@/ÚÐ†[Å!ÕV;]#»ŠQ°+¡ÿmÿ‚‡èA¤°vcf1Š¦1Ž=Á†‘À†`G;°I¸à@-t`•è†›Ð‚Ø…šQ'JQ7âèA+èÂhC5áEúÑ‹¨Ç îA;^À³x:&p,˜ƒF(~J$<à,·?ÜÞì–Gn:Í'Æ^Ä7·¥r„| Íˆñø9X"/ ãf´ð§pEZž–­›åÖ:‹ÙVèÜCgéˆy€n27˜Dgyäe÷ÝÎ»íwWÜm»Û˜QÚ’ƒ#ò²øËÂâï}	Ë5’§S,ü`Š?ÏÇrÍüùE+ŒÄÒu¹&Þµl½D?¸¦8 ¾kVq#ÝN£æ>ê7ß`2W´¼HV`ò#9ŠØ3¦y3büû‹ÿÇC÷0
-endstream
-endobj
-
-144 0 obj
-<<
-  /Type /Font
-  /Subtype /Type0
-  /BaseFont /CYLIJZ+iAWriterQuattroS-Italic
-  /Encoding /Identity-H
-  /DescendantFonts [145 0 R]
-  /ToUnicode 148 0 R
->>
-endobj
-
 145 0 obj
-<<
-  /Type /Font
-  /Subtype /CIDFontType2
-  /BaseFont /CYLIJZ+iAWriterQuattroS-Italic
-  /CIDSystemInfo <<
-    /Registry (Adobe)
-    /Ordering (Identity)
-    /Supplement 0
-  >>
-  /FontDescriptor 147 0 R
-  /DW 0
-  /CIDToGIDMap /Identity
-  /W [0 5 600 6 6 300 7 12 600 13 13 450 14 14 300 15 19 600 20 20 450 21 21 900 22 32 600 33 33 450 34 35 600 36 36 300 37 45 600]
->>
+<</Length 647/Type/CMap/Filter/FlateDecode/WMode 0>>
+stream
+xœm”MOã@†ïùÞC$8°¯$€P%h‰Ô¢h÷\2n7Dù8ôß¯f^V«=PôŽí±;ãüÛËöêÞwï|e¿+zå±›‡†¯VO»>Ëóu×ÌGÓfÏþlo©ºfä‰V›õ&´S–ç›Ð|ÌžÏ>ÿsyàC¾bZÍãÔ³<k§¾¥Pª‰6žÃÔN'R—Yžÿäal»pK:ËóÇàWÝ17fÉA‹—¡k¶<Ñ¾~LôófÚo›ITúmŽ»>oOãÄÇMØwdáåç^<‰ˆ¯|hÇi8ÑE*ì’<ïay<m8ÐÅ¹Ø¿ŒÛ¹ï?8I*rðéÿ"ÂÿØ™üy*”¤¿ŽÞN=Ë‹_O?›ÎóØïváÀÙRJ-é®®ëz3þc/+„½ï›ß»!¹ë%Ý)åì2)õe¡*(—”QPER¥Ä•P5T%·\'U•P7°P÷°É-Pj…|+¨5lê·h¨
+q:6@©
+ujð•7Pà«]ƒ¯D¾ujðU`×Â÷ %|b_¹†Ÿ»_ª5øœd_y>+6ðYa Ÿ­ŸAœŸŸŸE?ø
+±ÉüP§>±¯@ø
+Ôb"Ÿ‰ÍJ
+|DFæ'µ€Ï¢ƒ|ºdÀWJø:oÀçî“²às¸Å‚¯@v¾B<ÁWã>‡Z,ø¬xF>[ž”ðašósøv-ø*‰“ù¡g6ò™8ª¤Àç0>‡~Zð˜Ÿ>Ä9ù>çäý¡óN¾OÔéäý©ô”åÍÆGw×çiæaà0¥Õ•VFÜmàÏØw}ŒJiyž÷pTÏõó“~
+endstream
 endobj
-
 146 0 obj
-<<
-  /Length 11
-  /Filter /FlateDecode
->>
+<</Length 8357/Filter/FlateDecode>>
 stream
-xœûÿ ñû
+xœ­{t\G™æWuowK­W_õC’eË·u¥–¬¾-Éjµ$ëåv¿ô–Z²dw;±ÕmI~ÊŽc;Žãdâà&(„°á1KÂ{€†%Ùj;G$›@`X`³ìf†œã=ËÀÃ&`·öTÝnY2vÎËêúoÕ_ýõÿýº- ExZçÎœV•{¼ ü€¯8qðØ_v¸~€RçÁÅû/ïùPö1 ö©CéyÛñðï€¶V ‡-¤-½´PwèØé³ÿ¥²ú0Ðö!€4.Þ5—žûÍžþç |âXúì	éÓ¶{€öQ êñô±…èÿ´/NÜuêô}çN, ‹ ¾râäÂ‰ûÿç3;€®F oâOÿ7ƒD¥Ë ••.úúÊUj[¹ºÒµnìÊšÑ_çÆ£ˆ"€ }ìå¿·Å¿’Ã"ÈñÉÝ ¹wå÷ùgºL†è+$0è*ÃL"šTÕ‘Ë(aæ{¬½š5&SÔ¥™£õé—
+P€¹9mµÛÍdk‘‹ §B>Ft¦¦øÕ5·æö1IWç/I'Baf«©T(CáP¦^
+3ž>«²bÑp8=ÏäøÙ‹”Òp*ÄÜÝ¼÷b©“„6ªŒ†µÐE;±‡S!!žXH^tŽéc²Î$/s†|=æ
+‡sÕê¼Ê^‰3Ù³çb#)	Gç¢ÌM¸™TŸœº#áÖÜÕK	•Åã	7&«UÖÅ¡®dRÍØéyÖO¸sO*kåã­ó•xB= .-¥Uf'RÕ*Sù˜•CêHU§’Éd5£õ¬8<Ç0•`áÈnV®a5ªI_¶aŽc\6a29ŸN2âM&s;HªóÌÖBI3éjTer}z^e–p<Á,Zˆh¡j·;ÉHÊÇÌBÜLòªóËþÊùv«öù'3§¢sÌÔäVYAX]R—ñfZMõLöL&RñêôT2¡%ÝI•w&ñVs¹äXñ1‹Î
+ÃÞ‹ †štV¨…4•A¥Ý€‘9FRÌÒäc…ºÊ¹-Ï]–±_åX0•ä(©ˆàÖª_,,E8jr¯N‘¾ÞŠ*Ä«1„™\ŸR£KZš+UÕ\!L­fÁU1©^KGŒ%Jn3ÕÅ|rðV“J¹ýk¡K%Å¢ñ„»Zs'›Ü>V¦g(²ùtÄÇl:#)UeeáaN@eeZ(Élüi*¡2›Ð—¢«Ì&„¢^–1·¤¥™N©K)•)ZHó±r}d:‘‘ç#É:V² õ1»>2™ÙitV»“uÌ.úzåá™D¦¼<ÌH:Ä/?rŒÖ‡2eüÃFëCŒ¸4•IõñD†‹Éõ¡¥%•/kkrkŒ¤ópµ1Î§ÐzÑ“deáf¤]¯¬Û¨0Øµ#a†þ‹„¡-§Žht:ÁÊµe¥Zˆ•hÌœ
+©Ì¡…Ô#é++	Ø
+…¸$áË8
+¼ì1oumÒÇ\zN¯UèÂÛJ=Cy[¥g$ÞnÐ32o«õŒ‰·õŒ™·›ôŒ…·5z¦€·›õL!o½º–W3§F¦šÚÌÈ^~l|L_3èZ¼Ûô­ô¬ž4U¬Ì{»ó½>oì•otíþÜzª×Çjõá­¦g(oëôŒÄÛz=#óÖ£gL¼mÐ3fÞ6êo·è™Þ6é™BÞ6ëj¯°Ü]M±Ê”ÖIqãHóÓØÌ·Ug-^ÖÒäc[uUPo£V-Ý¥qÿŽÕ|÷my]gJÍQnzlkSÆDœÑDkRìÒ¿F<·Ãi×Õ€à< #‡ýã5ñÞ’ÞÚ@¤_ëÊ´'ßk‡®öª·áŸ!œîò±N½¹¢×ÇºÞ•‘ð\—mÓ3®zµYà¾Ñú¡¥¥m@K«‰ýÕÜýj¡‹]„8M>Ö­3¸X…br=“ëZ¦!Vö.,5kªÚ»Ôåc=ëÑÔfƒ3k¡<¶ÊRÜ¹'—dÕ¤V_’=¦Éw¹Ö°º¤‰Z,ÅÌá›ÏmŠ»=#<ÉáÔ¼ÆLáô|<Áäpºš™Â)îònž“ÖT•É-–îªÖ˜5ã¡Ë«¤Ô[-¢ÎÕNqe˜êÓÌôGT™ìáLÔs&¤úÔ|Î¥ÞX+éc½yY¨ªÊLžœ,´Þ.ë[bV1Óø¢\‹ý«"ä›1$Í0hV{5·¼¹N•ó•S3×3SýÐÚ$ÆPâ­¬=§-›üö5œ„óêJñLçæ-çUÔ5µ™K1Æ*Â‰xõT2¡ö&›3­Äáõ±ëF§ªãëFC·œûN3Â:ëö¾Ó‚õx—Tµ—ÛØR×íQ™9ÜÌZ½>[æöé1$ŸfÅZÈØ:7PMíU›µ®ý˜ž±Êõ¡ü”?Ñ¤þ½¬˜ï‰û±^­«Ú½Æ^ÜÉŸzÝÞ¼Tõz¼n®3Îhn7«"ÒœÆ±¿~ÂíÍ¬£ÉÇ†oÓ?¢g@vÖÙäc£:ÛÖäcc\ŠQMmVcKZ:/­q4óúØ„~ˆy},®_áÀ¤~‘ˆž)ý"=;9Î€×Ç¦9f8vqìÖ/{},¡_â9”×Ç’ú%bôíÑ/£ïŽG8t'ÇÐ^Ž' }O@³|Í¨×ÇR|M¤ùšØÏ×äÀÇôúØ<ÇáÀÇáÀŽÃƒ‚¯ˆ×Ç	¾8tXðÅ¡#‚/|qhQðÅ¡c‚/|qè.=ƒÞUžO,èõ±»p‡×ÇNr¡‹§×ÇNé’Ã9m€çCr8gôúV©Þ+žÄŒ³ÈgÜg€ýœž!9„û#<`€áÏôúWé=(žúyäè GŸž!9„È6@ŽðˆžÁöUzïOýÈÑÿÜ 9ú£z†ä>h€aÉ 9ÂcúÅ"‘â2sõE™JÑ„æ®v'“!/+X`R]ül>Xûxˆ¥PÚ%C‚[‚Þ'”‰Dˆ´[&’DfA$2!Ë²E¶”+6“¹Êkw+îzÅ­¨´òúÏÈO²)©øÚÕ^ú±ë‹ Alå*Ý@_Ç4½®Â™2
+B04J¥4'=,Ø€ªúú:“µÊëòÚ;üm®
+‹Ç£ÕšN‡ËßÖÑYa6kß8þÁÝéÍƒ®íÝ“;wNvownNï.~‰±—vÆÜÝ÷/ž\¼¿»ÓÛÉ÷Eh]Fj‚ÕfP2Jù“¸‰b\±+å²uƒ×®)šâ·û¿¢}Ö2zï¯,£÷Ò‰ëº|ýE:t=‚®•«ÔJ_‡/‹JK¨‰‚H2…_°&È’I>JI„A’6`ãÕ#¬8žÖÞËlŽ¨Èc:Þ½÷B*™L­Šb¯¯¯Ó,ÖMÞzÍlÖjo)Ý@@øüÉ1:q÷–\¨tõwOMO†Æ?úæøÞÖm/>óÜòLÄÝÙ}îØâ‰ó“¡Ápö ˜^¹JejC×³Ëy“žGoÖs*ßIÏBÍßàcƒ©Š`i¨%:>>°¿i[åüpñ“<ðd°³¶QßKÄvïièÜ!l7´r•º¨eØ=¸”æ6q³MË„a2n³¶M¶N”¡Ôc¶Vx]Î çÀåt˜ÍZGG Ð¾ÊÉ•ÃÛ¶ŸÑx<Ê‹Cç¦¦Î…ŒÏèÎÉan„Ã“ÜØöäµÁŽGŸ—•HÎ2ìB#„ ±1“L)Ð¼9T€w‚³É-sí°ãv3o;‰k»€vÍ®)fë¯_ñ;ý|ƒNESŒ­)ûãò–#Séxo`„ÊÓ©C{³Ï“¾XÌßš}Jì#ÐJ*Ãw°F"dÔ`A"b XìŠl­ôú%¿Ýo÷Ko¿4ù”üÔÄKTÎn'ÿíú5®—ðÊUê¤6T¢}Án§ƒ
+»A¨LZˆÉ´Ö@Ì†TUUµUîš¨D…æðC¹¡(§{; f³ÓéæJûåñžÞ£±È¡mÙ»ý£ÎžÊcÃ­±FÒ8,›œ¼?¼ãä§2šhñ6vì ¿eP·Efø~9ŸÅÔa¿”È d4ªFÇ ¬µ_ê5Ý°ß†N—8;íž††f*Œ¹Â"¤ìpUTÔP§Ã¬}*ÙáÙÓ³}¸Õ;¹u¸ãä¾GÆÛ;ŽöíØÚ4Ù683_¼Ð²¥Ñ§×«æbKUOûÈÄÎ­;šó£3 Ø
+Óe8…g–åð˜™P*ÍróŽqîŸ2®(Šâp‹“Þép¹ü~§Vëñ-àø~§ö›šmÛJŠ'fý'NÄŸ~úË­¾¢HõhŒØ#/¼1üåwVN‘x*ƒNð3¼›÷Ï‚€L(6j­ôÖû%÷
+?šý1ç@¾@e”p{¡D2„—·[HRD·»5›p³Â9cf§¢ˆ›<¶MÆ©|áB|j{örçÙCm¨Áü[°¨\¡T¢ÄdÎ{Zf5„$ÉiÈòè¸-‘
+DÆ
+‰Å’Xõ»[n3§€ä§!“üÑûÓùèóSZ½y3Áæ-›ëj7U»¶Ò¢B³ŒRcµº¼îÚÍðÒ~¿pG–aúÂ)ùîªkÅù×É"SÝ½“©<ìÙ§w8ßqÔYV÷³øñ¥mmÓ©é¡Oø»ºGõÞ½“o•9c3ãÎ†&Pô®\%oÓ+àR~ö…"P“œwWAit²œ3³8¨Òº0¦Þ„Ã•œC\ÄÞ™Ö»“áÂ*U¥FÙäQìuµk5bùV!ÂµgÛ&-·›=ztöX›ŽŽvEÇÇ£Ó©'ÎŸ"EÚ¯oìéj[nëšHL¹ÏìJÝHm9Y”Ðu²å¼!s¾h”s>¥²f¾n7ã9Þ•Ö»“Y+{fã²0ŽS_Zmƒ¦hX'‹ÙøYªññh×èhwúBÙ+DrVV„Ü¿M¯ ƒ+Ga#C 
+2 ÌÆ^qÞï\¹J~GeØñàó Ü§Â*—!1îÍ‘–×™‹+7"Ëcx‘ÜjÞí¦$“É»f¯5Ý°Å¯)7òùÑ-çÑŒd_ãÑàa	û üž^•û+ÌæB‚B‹I†•Xe«ËëÏÑ÷û—}ñ*s=ý×ï¯âù` E¯äü²$	mEÇL„;LžuÄDBfç^¹N±q¿lç¾˜‡2áÍNî•íÙC‡ü³®ŠmÛj>øÁ8y%âVGŠ|­í‘lPð<HT†Áº²*ñ¨l’‰´>.;àp(N'ýöŠ
+g§ßø”4I³X4éé@˜ŽõôOÐP`ä£sç©$ý1*ó÷×¾ñkxýú5òñ¿ú5µÄ×<Ð~z%¨º‹¬jäu@t|s¹eíåŽœkWøR»&YœÚá¸¼çËûßø×¹¿MÆé•¬oæ/ÿ{öuR<ùãÌõ®èäm‘36àj°ØUDÍ&³‰šwòn˜LFÔ³³Y7Â¦0¸j[õåw¶Rïˆìx¯T·¼wªÁZpmcá¶è"-KË6lØÐ°Áã±×ÕiµÖÞzqb;]þ¶@`­CøézwööÙ£§£-3OÊmÇö-.îãGùS9¯¦=7ÐÙõÔ®ÔãçÎ=žšÎF»Ú¾Ì]ÛðÀ4R€TGm¨Ã/R*­z5§™pWD	åÖc1Q¢sò¬~ˆc4¯”F×"8n?û&rñœÔ^_g+°ÖnKdþF³&;½¤â²#ØÙ1í ¶‰þ‰d¼³Û‹wlóÆ©<íó·š{ŒÔ5ó·dŸ"}±(oÛý@ñ0$T]œÌòk
+ðC"AR$k…·Þ©Èâ…‡~Ø°É= ­§Ë(AÚ‚-…„KÌLdH¥ƒ0™xDÂcÔpe¥.GiEY…ârÛ,<×ÖÃó uò’ªÝ£iÊ³ÓÙÔÁäÎ‹û¾t×==/Òå#³3
+²? M­í[+Ï{VkÕ‘~H2•"Çz˜»BÓ,
+ßEŠx¾§ð0àWÜÎüÏòlöód<{‘ì¡ËCÿ2tuèFmrvî?¨(NŒƒ¼ZEÈ¹Ó¬Ù5w®ü8ß¬›µ¥?Õß¹©x 9ÿ2já¶ª›ËjâR,ù0 Ó,L¦0_ØˆntÜQ_ï©³™­½Ä-ù×Ôcµž|‚mKƒÝM~›ý–Ã²1ÔÞ—êØ¶8?Ø°]õŒOú¶m¨"Ð»³¿õxÚÓ¡Èáî­--ãÑ‚èxÍ&+áß9à5¼J_‡NlæU	äb’dÓá|³ˆ²Ñl”.WAàÚìª©®*p8ÊJ`¹¶—ŠÍß¦Øn*=@»¿Íéth]W¯^ä¿ýýýýÅä09œý‹ì_ÝwüäñûÄÇÿiuµ¶ºø· Ý"ô¿%è1›$‰ëeÕâ¤w[)¯{§ÂK?/Ú-¼Ð›ù–…m}éáËCÔÿ¹À3×ŸÁwWÎ_Ñ·`ƒg„UÆÁ"žÉ€ëž»¯B¾îûAÈ™äsvžÝ—wttúy`r¸*´føn×¾îÉ½÷Ý·w²{_ùø³KÞØçv{#æ]z–RY9C[¿>À#+k÷X]£Îl¶ä¤Öà¯¡NòØÚEþ÷­Öh]¹JÍôuèˆwY)ˆƒ˜ n¦²IåW"&&~X„QñÃ"\ñ°4NàÝÂóìÒâ3t¢[¬./YcSy{³8oivZ€”ŒD{Û‡ëÝß5ÒÜÕ{lpúHÃöÍÃ}CññÑäÉ`»¥£»ÙÛzrK¼38]&ïî½Ó/ì/Ú_Ð]:@—a…TMDÄpž†×Dp+¬Žr^Y»‰o»_RýMj~FþÊ¾ßròÅ>Mf²‰ì¯„\ž&fòU²¿ßZS¯QÂ¶5ÎÎp;Ÿ&µÄ<=-lm¥‹jT†‚Úàæ²"ÊYá	HÃH
+„’Õ¢ø‰Ù¬i[g§`ª“ü0¾û¶®Ñ;j¬-ßŸÚ=&Qùúc-‘êSä÷?þú×ùU ÝN—{Y¢„ÐYP[õÄXEØ1Q4E¸d×ôÏ©‡Þ}ý	z÷ÐPîoåªð‹ÎU:‚DÞ} pÂYç%¹]á…o[‡HezÊçÊº·oï.›vïÛ»wŸ›.g÷NînkÛ=I>›½ûî‡Ãá‡ï&Okõ’"º‘Ì¼7yö’Ÿ’¢áa>o@«èë<Ÿ	Ö•–PI2ÎnÞ%)€\õB¨nw sÕsäK<‡ÙbqÓªlóÏ»úÂÁ¾ò‘Êcûœš{Ü¿ëmé¶âíÑþmöÞuÇðá/<÷t#•QOP+±šˆ|ãÊF–Œ»! e(+w–§aoÈå…»Ö Yú^ùJj¼_î»ó«¯¦ž”'æì±]»Ž]Ï¾ýíoƒ"¸r•VÒe¸P‡Ž ßJd=$™HGDhâAŸ¦MDè£¢¨¨«Ðj6Â§Çe±V7}Â±X*n{áöòù‘Óý‹÷=¸Ñ´qg_ßl ûh,ÄãÅOüYúÙ‡wú4m	Ò;"‡»&b±	ñaØš´˜·¥PâÎsT¤(á±œßt*Ng.²Ù×ü—4Iü¯JŽtÓ‰ÔÌ©wb×¥½wihï^ºœeÙ?‰gYö‘IüzŒÜI°‚ìçŒÚñ*Ý¸ZGßT;Š {SAÇOúðêý/únY ç{µv|'ZïNæÖµ£²¶vtjuï¥väA_Ó=kKGn‡gZA—aÂfÁp˜§Ê4uÃ·™`RŒ[C…g,g§É]6âÔðÊUòSºŒr~ƒ[X@‰q‰$Írå	Bù
+@9ÊíÆ2QÖ;lEŸ¶ïë8l‹mëèî¿F—¯ÿ¡;Ñ²sDié‡É3C7r­rºŒBQ»ýQ®e"²‘ùZ…(äY–q™šË±”=äröS$–]Vö5ƒ¦oå*­¡¯£Þ¸G”èº{Ä¡›ïëQWç­7îÁ×^$Š»Nq‘¸z“(tôwçšú¶ÜÙ?2ÙOM?pìÓ#=êÎ¾ÑžÁ‘:]¼£»­}kl{{Wq‰mahßüQ“Þ×³µ»¸Dýtú¸ˆ¡ m{ö5¥y•sÊ7\T¹RžwQÄÍ²›6fÈcÙ7²§É¡ž¡‘ëÏïŒ»€ å"‡¸¾þ­¯°%€H8ÈL.ÙÕ«J%—óñ/Š[ïÏe==MlÓÓ¤/û]Î~‡´_AÜLˆŒž–¡–ŸubŸBa†ËäCüjbe“ä{äÿÑ+¨EìÃœ›Øƒœ›7WÎ·é[° fä'vP™HTšË+\ä)¼~á—ÝA%‰îÎ[•&’ÁâuÁªBq;5Åï|“Tþð‡KÒ…þk¿ï]—[®y1´þ=O'×$’æÛ&’<}ŒŒÄùï­RGas3üE•QÈWä×Â‰½¨TD,7N‘6¢°\1"@^±Î2–ýùdöÙ=FNEÆ²G8ÝÙ•3äÞõ2…îÜ*É(w<Uü‚_ùÃ»s%ø#™ÅÍSÕ ¹7û³þ¾uíÁ~ÉÜ/4{Œ|Ú…Ö¢BkÑùçf€v‹ì¡¾`L 1á d9g°fž	DÈ8Pd-,È-e±VyÝšE³ûíD“üäÍžßöì~ã®7²¿+ÜÿÝo~“._Ñtö¿6Å¿åû
+]EdµÜ,24¼ÁFHà•_sÕ/ä|™£¼¤ˆçjun³áÏ?ª)ÊjÞ¸'›:x0õ¥5ßì‘ìÉÝ¢â3¼¥¤ÐeØ¸æ¬”Q³‰t–{L¶rÛƒ6Å®(îµ‰E’rï*í~ESèç{¾ðùžª©ß’ÿöÂ½'û}Òzúúót9û(9{=FGó7.]âÆå–7¾7jö·¯7ßrRzóõäÍxŽw¥õîdÞõÆ—[}ï7¾Ó×Û‰ôG7¾ Ué2
+PÎ}aÞõq™S*ÎN„Œ[•²Ârkyj²Vzíyß(ìg_;þüù×^žÚ½{ê(]fÏ<Ã†NY<rúúAHáÊ2Aß‚„fã‹rµô²ŠÒ‹êL’?¬f–&Å¯ÂØ’táÚƒ Ø±òçR7ý:z0Dì#¬9žxÁ]NÍ…d´šÖB2šaø;Žb+5K„˜éþ(ä^<¡°PNó¸+äºÚO}ï<ÁdŠ³ŸÔO[a’eSáCï¾Zn^0°:…XÍÔšÄ{šÇ-ÁÝÛKÐ;Ô;ÞÑÝµµeKC¶yS…ÓVZhAé)±º¼¦Úuoqy2`¼åÎ÷
+“É½ãn1U˜—r“½|ò™ÙôÅÓs_<8“ln3ÉÎ½u¢¥e¢ÕÛU&G7ljÞl×¾NM|dï?­=àoooo¿oaùÜý/™|æánnlÒ·ÎÎmmÒ"Ùï{6¦¦›w½h×'îèÙ÷äTA[ó¹Æ¶¾@<Ðgdyÿ#Á´ðòDG'ãŠp“S´Åéiî²@ðOä{äãôJ÷Fà2^ÊþRÎñ¾Saz%÷Vî5ò=rß;ãw„ï3ðWVðIzˆ|•þ îÍ3?›EyäòJ–¼<Ì
+@Ðþ=BRôGÐ1ÏG‚¹iƒìÎ_´¬-•2fD¿kK¡?:rÇù_{Pyuß1¾ïHž7¾ïãñ8•s÷õüÄbv{Û?Ì–õþég\xoäÇ¼ýqìøÙ3+&ùƒ2ß …ãŠIöÿ2ËžÉ^“?((­ý7LPi1š@œ&ÐE^hÓ4M`?M Hó_ò*¶Ò¾C^Å‰Üx/M`–èHÓî$:ö‘W“ÁMà0—AŠ&ðšÀžÜ/§9Ä×¢	hß¥	¡	´ÒšÀÓ¹þªO|4>Î‹ôˆèŸ¥	œ¥	Á?§éËÍ¿37‡¯7Ix3·ÎLnÎ1šÀf¢c‘Ï“4Äh‚J`GnìŸh¯Ñ>IøÑ…¶š°ˆ'I©!ûÈg¨™6Ñéÿd©FŠIoÉšd“ËtÆô”éûf«¹ËüË!ËË«–_Ôœ.xµà—…5…ñÂ‹…?)|ËÚd·>býÏÖ,*-J}ª¸¶8X|¶ø3ÅÿV²±¤¡d²d®äxÉgJ~RZPÚ_:TzéÃ¥/•þ¦ìÞ²¿.û®í+¶¿³ý\!J…Ò©ˆß¢$ø6jqüË=ÏÈÏJxÆ€",ñ(.8)l’ÃœÌÁ¥ø9XBŸÏÁ2:ðËlÂR›ƒÍh%½9¸ d1â#ä39¸µ´-£–N#Œ»p÷á$ã á4T´¡[Ñ	CaªÀ:‰h†Š4Žc*c‡À8Ž9Ñ¿‹X„º†Ò)ñ´€SXÀIœÁæÑœ›·[à#*&qÒ8Ó8‰» b'¦°€ƒ¸‹Hã$ÚÐŒVñÓƒŒ`7ÆÑ#(­¥³žÊNøn¢òÞVVošµK`žÂaÜ…ãB:y^þÔõ¹¬IxyŠ;ps8”£3—“\^²c8Œ£Xxû±‡qG¡CEiA[Å¡ó¹]"-z¬ÃXXÝos
+wá”àc9Ì	,â°ÐÇä¼|ññS‚_›kö4N -hÁ½âÇÐj3Ž‹•n‡‘^ÅÈùÂ•'Ñ{Ë¿N_gÙŠ&aùS˜DƒØ…Ý(Ã"ÀNŒ"	aÆ1Œ8ÐˆTÂŠPzaÃèD.Â‰;P…nDÑ¶ }x¼Ø„çÐ6ìEÏ£:ühÅ40P¼ˆðaüÿKºët¹ŒoM%2„|8ÉˆñmîXB/£}íuf4ñ§`iRž”wl“·T[ÌÖ\ç^:C‡Ì}t«¹Ö$:KB/»r<d{¨ô!ëCÀŒ¢¦ì¡—Å_ÉåxïK¼^dêÈ£“	|4ÁŸç#™Fþ|¹ F"ÉêLïZ.xD>:7ïûJï ;iØÜC½æM&siÓe²ò~&?ž¡ˆ\2Í›áÇÿ‹S°g
 endstream
 endobj
-
 147 0 obj
-<<
-  /Type /FontDescriptor
-  /FontName /CYLIJZ+iAWriterQuattroS-Italic
-  /Flags 131140
-  /FontBBox [-71 -212 817 780]
-  /ItalicAngle -9.5
-  /Ascent 780
-  /Descent -220
-  /CapHeight 698
-  /StemV 95.4
-  /CIDSet 146 0 R
-  /FontFile2 149 0 R
->>
+<</Length 13/Filter/FlateDecode>>
+stream
+xœûÿ  ¬»
+endstream
 endobj
-
 148 0 obj
-<<
-  /Length 1236
-  /Type /CMap
-  /WMode 0
->>
+<</Length 553/Type/CMap/Filter/FlateDecode/WMode 0>>
 stream
-%!PS-Adobe-3.0 Resource-CMap
-%%DocumentNeededResources: procset CIDInit
-%%IncludeResource: procset CIDInit
-%%BeginResource: CMap Custom
-%%Title: (Custom Adobe Identity 0)
-%%Version: 1
-%%EndComments
-/CIDInit /ProcSet findresource begin
-12 dict begin
-begincmap
-/CIDSystemInfo 3 dict dup begin
-    /Registry (Adobe) def
-    /Ordering (Identity) def
-    /Supplement 0 def
-end def
-/CMapName /Custom def
-/CMapVersion 1 def
-/CMapType 0 def
-/WMode 0 def
-1 begincodespacerange
-<0000> <FFFF>
-endcodespacerange
-45 beginbfchar
-<0001> <0054>
-<0002> <0068>
-<0003> <0065>
-<0004> <0020>
-<0005> <0043>
-<0006> <006C>
-<0007> <006F>
-<0008> <0075>
-<0009> <0064>
-<000A> <002D>
-<000B> <004E>
-<000C> <0061>
-<000D> <0074>
-<000E> <0069>
-<000F> <0076>
-<0010> <0047>
-<0011> <0073>
-<0012> <0070>
-<0013> <0046>
-<0014> <0072>
-<0015> <006D>
-<0016> <0028>
-<0017> <0029>
-<0018> <0052>
-<0019> <006E>
-<001A> <0045>
-<001B> <002E>
-<001C> <0035>
-<001D> <0030>
-<001E> <0031>
-<001F> <0063>
-<0020> <0033>
-<0021> <0066>
-<0022> <0067>
-<0023> <007A>
-<0024> <0049>
-<0025> <003A>
-<0026> <0038>
-<0027> <0036>
-<0028> <0039>
-<0029> <0053>
-<002A> <0062>
-<002B> <0079>
-<002C> <0078>
-<002D> <0050>
-endbfchar
-endcmap
-CMapName currentdict /CMap defineresource pop
-end
-end
-%%EndResource
-%%EOF
+xœm”Moâ0†ïù³‡HôÀÆvÒ"„D‘8ôC¥Ú=C<°‘À‰òqàß¯âw Õj=Ûó>IœðÇûnº²õ§ñOEÜÕC[ò4Ù7A®ër¸°ë_™-Û[µ›SÓÖeÇ=åÛõÖU}†[WžË·9ÿ›òÌ§Ê}M{P>t}}	Âð³êÏ<§	Èg¢­e×Wý•ÔC†¿¸íªÚÍIa¸q6¯/c¸.ˆ¤Eïm]î¸§cål+è0ö´![•½¿–—}ãï®]Ï—­;Öc–™ID}ð©êúöJì,Qyk-·•;Ñäö[q74Í™Ç¤ü(;ëÿ£QþuaŠDø>*–¤¿†>¯ËÑï—ÚÞ@#bY[îš}ÉíÞ8X(¥Ô’EQË±ã?õ$Ã²Ã±ü³oýt½¤…RI¾ôd<Íž@1hJ<e	(E-Í@RË<zD­ =6 öŒAÏ Y—ƒh=eÝÆS*Ýì	=Þ ¥f¿l?ì©á—ÁVÃ/…ƒ¿GüäÔðËÐ]ÃÏà.iø%È©á—d ø%’~F:ˆŸd?É	¿ýüb!øÅ¸g~1Ü<?¤6ð‹…ÄYŒ<?ä4â·Á/A2¿Xjð‹á`àËžð‹eüRé¿LÖÁ/Uþ••ws|yÇ3z?-åÐ¶ìzDýÑÏAåø~Ö›ºWùŸÿHÜ¾7#½þlGc
 endstream
 endobj
-
 149 0 obj
-<<
-  /Length 7391
-  /Filter /FlateDecode
->>
+<</Length 7528/Filter/FlateDecode>>
 stream
-xœ­{yp\Ç™ß¯û]À` Ì`€oð0ƒcÞà ƒ›ƒ7ƒ‹¸o(‰œÁAoQuxEY–—†mí®åÝ¬Ë®T­µöÖÊé!m™bR‘¢T)vyË[›ÈYoÖë8µªZW6NþXÆñnL ÕïÍ€ IN…Sxý½î¯¿þúû¾þŽž!€\…€ŽÕË—Ô²#Ú{ þ5€o8òÌW{ýïä4Pæ;yú™ÿûÑ¯åŸêŒSëÙ5woòŸ ý{ zOZÏ—_¢ ÐxêÌ¥+O:Ã@´À;§Ï­fßø«×o Ñ ¬œÉ^9/¼ìzh› žÍžYO]^ûÐv
- ÿãü¹'/I÷òe ÓðÉó×ÏÏ¿õlèü	€ÿŠßüß<æ‘BŠÞ¨l÷Ñ÷¶oS×öímUö‡ŠÛ·ùèE/}<ÆÿöÌý€:vfŸ¿ûÑƒr OoÿSáÞ"Sô’t•á9–VÕé›([œfòòQ“uXs:sBÝ<d2Ê¾U„"¬®j+`!ÍÔR×AÌQFt¦fNDÕµ Œ2AW×n^Œ$ó$ÕLÆÈQoÒÈ…„$£ÉƒWTæÔM&³kL\¸rRšÌ,¸^ä½×Ë|Ä¨UMjÆuñ$3†Æ°`®§¯û	ÇŒ2QgB„ù’&_ù“É<B@]SÙ;L½ÞLJ“c«cL3ƒL¥—1ƒZ0°iªlaÁ²D: ²>õ¥ÓjÎÆÎ®±æ3˜SYïà˜ï,˜ê	us3«2Ç‚™	¨Låcõr¨7È¤Óé £!æL®2,™Ó9ÈœÉÀ4«çPýtö¦«ã¦„•tz-›f$’NçwV×˜?©é(“tuLeb(»¦2%¹`2E3X‘f‚Á4#™(“-q3!¢®å”Cåƒ|»›}þdrfl•I­A•%ÕMu“‘H®C
-11¼hfÙ¥´©¥ƒi•%–MF".—<+Q¦è¬8¹j«¹HgÅš¡©š‘etå#«Œd˜ÒeÅºÊ¹-K®Þ±¢r
-,‘Is”LÊâÖ¡_/.CrÌhîN‰¾×œ6Ñ’LeÔ±M-Ë•j	®¦XbG`LiÙ”½DéC¦³Æ“ON<hR·Í¸Qê„0¶`Z0ÝŒ²r=Gé[Ë¦¢Ì¥3’QUVž<À	¨¬\3ÒÌÅß–L•¹,}¹u•¹,¡¨7E¬njYæNfÔÍŒÊÜš¡EY…>}ÐÌ‰k©t#+]×®D™GŸ^4§—íÎ@0ÝÈ<V¿WÏ¡"yÈÌUT$ÉÌáGŽÑ‘+çŒø5•	¡3ÇÅÇÄ±¹©òe]­A‘lØã|
-Y=iVžœ`®äD†Ñ½Êzˆ
-s€GK1’d¹N±´åÓ‘;h²
-ÍPÇX™f°RÉCe^ÍP3Œd¿[UEà††apIx“>–óEØg#†t”ùõ|‘(«Ôs„·UzŽò¶ZÏ	¼­Ñs"ozNâm­ž“y[§çÞÖë¹"ÞîÓsÅ¼èZALÎL45µ‘Çø±‰2}× gð‚=Ý5Þ¼hª:Xyäaæ{ýŽ½W¾ÑÝûê9¨‘(kÐs„·šž£¼mÔsoCzNämXÏI¼mÒs2o›õœÂÛ=WÄÛV=WÌÛ6]²,·]W3¬*£&5F2Ü8²ü4¶qãíÐY{„µ·FY§®ªêCÔªeû4îá?#ÀwßUÐu®Lã¦Ç:[sñ™ik—±]âyN·®öXœ÷èÈãŒÝ¿&#‘òÂûáÿ¶2S#Z_®›øø^{uuHxÿÉl_”Åõ¶Ê¡(ëû(TF’«}QÖ¯ç(ü!µMà¾ÑÐÔææ„6¡eUs%ÀÝ¯f\ï#Äçm²ÁÏ*5ƒ‰!&†,´œ+IFÖ7Û4UÚì‹²Á½hj›MÉšQÀVY†;—Ä¢yCT%5pCK5iƒ»\GRÝÔ¬Úx†ÉÉ{Ïm†»=;<‰ÉÌšÆ¤dvmÁdb2`R2Ã]Þ½s²šª21¬gûs$Çyèr$­U2êƒÑlç*'3\R(Ë¤û¨21Ì™q&„Pf-ïRï®•Ž²¡‚,TUeR8/m¨/Ê†w†˜Ã×&ø¢\‹#;"ä›±%ÍpÐlS‡´ xó*ç+¯
-&‡˜šÚÄØJ|µçµ¥q“ß¿‹“dA]žéÜ»å‚Šº¦¶q)Ž³Ê¤¹XJ›êPº-×A¼‘(Ý3ºXØ3j<pî‡ÍHêl òa¦t6ÙTÕ!nc›}Ger²uD¢lÌÚ2·Ï°-ù,sj†½un š:¤¶i}yúãzÎ!†ŒÂ”ßÐ¤'þY1ß÷cCZ_ ¸Ë^‚é<Ÿz‘‚T&õ#A®3Îh~7;"˜Ò|ö±¿~Â=m¬·5Ê<¤ZÏx=,Þe3:ëo²Y.Å1MmSÇ7µlAZs:7h6‰²yý:0‰²ý:õëÄêYÒ¯«g™ãLD¢ì ÇáÀ!ŽÃÃ‡Gô ’‘(3õ<‡ŠDYZ¿Aì¾£úb÷=Âñ‡åxôÇ³ cÏ‚Žó5Ç"Q–ákr Ë×äÀ
-_“«g2ek‡ë‡'8NZ|¥"QvÊâ‹C_zÜâ‹COX|qè´Å‡ÎX|qè¬Å‡Îé9í(ð¼õÆ‘(»`ƒ£‘(»È…n½‘({RÏ‘<Î%ä8OY8$sYÏax‡êÓÖ›5ãŠòÏØ GVÏ‘<Âs6Èž·AŽð	=‡‘z¿e½Yè/Ø G¿jƒýE=GòŸ´AŽð’r„Oé9ìß¡÷²õf¡Ú9úoÛ G¿¦çHá36È6m#|V¿^b¥¸L\©0fjÁ@06"¬h	W
-ÁÚª”)T€ö	NPÐ’ó>ô¤HB„#"rD ó¢(*¢RávIruÄtCî [¥Uw~N~²•œ¿¾=D¿xç4@p Ÿ¡·  ˜¨J=Jga€ÅívKŽê4*äÕ¥ÿæ¤a'½xçzq’æ ¨B?@5š”PÌ ž… ,7§Y‘P:Dç¼!_£Kr"ž˜ëíuù}^EÐ<½=Ýa­A‘AûîÜ€X¿<8:-wÏÅ¤Hd¸£ÓÑ1G?Øz}tl~\Õ¶¾G:ë«Û»û†¶þSÛ·©—ºP…'|^J	™BE²¡IB–ŸYP*de"†0W]T7TëjQ…ÊFo¨ÈQñ‡{ºó<ÉŠìóúc]½ñJYÖ¨¬(½‹×7¦^\šËþó¿!ñ½3ÑxôÂ¼´RBþäJgóÜÙG¿°8eŒgdGib:¶¿áÀùëc¦CÚßÞ±å4·}›ŽÓ÷P‹¶D¤ºª¸H´x%ÄbqÔf‘«Ó¸jh
-5røóœU*á°Ö +{Ø›ëûü%óhégoÿÒšÇUdŒ÷ODF#ÒÎ_¯üø+GSUÝÏÏt4O™	ši[_øý ¥\_E$ÏÄ0_Çb Ó¡È(%¥¢Ã‰5„{ºãž˜àóÆbÊ‹Â™Ù³eÃ¥uÅåôówÎ‹Î(Û·iu¡û 'Z89[ö7Ñ¬H1È\YP¶¯¬¾Ò‡R8C²£rèe­·7·-¢°ÓoœšxnfåÔÄó3ÓéR‡dMØóéÕÌ«ó—×2¯Î§Ì¹¡z_b¾±ä½¼}›î£"ªñ´Uÿ'*BÈˆµÏ‘ æÓÌ¹`&üùQ²‡Qõ>dÞÃ¦¤Óéïº½!ŸÆí<¤É²V­´x/‡5ò;0óÃsÏr+6¾­?Ï[9©»ókPômß¦SôxÆß)#’HfìMÕ‚ÒaÎFþ¬É–Í{¶§ÞƒAÊ#îÙè‡Óúh2ét:QæõzÃÞP‹ÛÒ”Ý2°M8ÆwŽß§còª [î<{¨Î%ôÌ=?7k+ñP£wÒt:Å¾žgÔ‰•Ù×ïî"wjûûcÉ‹er¤ëÈôd•o0‚×ˆB¾OÒPŸ€Ÿ«#ÜŽSB@æÜ‚£2â‰•×ÊH}Q––ì³ÙÐz%¨KÔÈ„ÌPBÈàlþ<¸=î
-ÑQñh‚æ‰ñ ýe}æ©§_¶žôè×é­;¯Ó£wÆ‘×—F]–¾Ø›å„ÞUXµ%@N=5k;(Y »µ¥#{´Àå¬Ü¯®¡ô1ˆpey½^€««¾x¼¡Fî
-ƒñ{t	RÙÞ=:+Ÿ;üêÃTvôÎ¯ïÓ—ûèömò.½?ºínW¹(ÌX‘ˆŸ4rÜ>eÜÈ‰{E?|n·Ûíã¦ÅýFÜ£Åcñ˜S4¡2^©È²öGMÂÐs%ÏÕ.î{£ä„÷…¦ò¹d3ÜXé"&ß|3¹õIçB—£[Ãö6÷…¤‚¾´[±¶í÷8WÆö¯hu ÑDk!”:SLèðH)K¸–T¢Ò×&:ª"D¨¡=ÝMqÛ“Ù'_‹%Uºpq°v:xìk„›Äî³%TÜ(.9¶9;÷ï_:™Û7”V‘G“¶5Û·é }®¿Y^F%Z°zHI<	J-ÅŽòCˆ¬¼ç¸7< K–‡lÔ=ôQô>)nG·Ûñ_wïß³xÈŠkqîþ¾.§GÒô®»–W=.ùÙTÚYü…’ŸöÏœˆ^}¾¿ž?ŸiŒþñ±É^cë–|:¶oSu¡™GÒJ¿@EPËj
-Ž	ØI›ÑŠ„¬HnŠûyèìé75…9“wyôyý••õÔç•µwÏ7ì[ìOÍ75NüDÆÈÖÇÝƒÆxKÓTtDá”³«½­)ÜÓ¬—Jý£ó‡ZÂÕ‘†ZÙ©ø{ÚãÖäÙî£jÞ|ëMÝåj!ŠÈØÖM³ ÔàrMwÝ6ÝëŽïÅó~$­&³Ëm7{C.~¶<1¥¢YêlÒ;.@)ø€ÏÎíõsä€}öÇó®€Šw½ÀÖO	ÉŸþ‚3°ôÙÐ£ôŠ­ü–B©p’;ðã g%"ŠC"×d1Šùé—5‘˜'¨X¡ý)ò¦së+ÍdÂ¹õV½5ù‹É­gÑíÈûT„‹g:l#Áq[TÜ@†,qÁl´rÝX~ß1…­¬ý‡ç*¥:s|®ÔŒVu:¢TÜLNÌUú†·þ¯1Ô…n|3QRL© UQ y5×Ø—jé@ÄãE2µ¶“Wr½¥ŽVpå÷by?‚ÎG‘àêuú}-A_¨ÑUìØwW¹•;i8w –¿ÚÑ°œOÍðë³>)0ï–åš¹þ„¡tM•NîÓ„9ÜÒÖR©É³	y²³¹&,ÌRñÄ`|¨w ï@JÕþOª®¶¨üÖW·¶¶TN6lýŒŒÔ×.5×Lª[?³ôôÃíËÔ ¿‚áiVµ`&J@@>Í«î„Š9ÎË ärúÛÕê¨ŠTôöÆcrÞ+µp¸ç‡Ÿš>ôÄW¼eò¡±ÙÑE2ñ£?éšúÑ•CáµoÆÿÕyk–íËäµ½ë€àÓ<û%Ö:äe ;ë@–•„´)æ÷ûÈk÷,ÔtßBÔ²çIz¥¨ÆÑiÖ´`&
-ÏÙ($ºYæÛÝäÂŠÖ’(Ò‹
-‘ ‚»Û{qÒ	WyY•¿¬º¼Úíö]EŽ@$¦yòõ
-OKâÜ»ZÊÓ„—žúÇC‡Ï­¾~úâÍîT‘,ÄÚ¾¡·Ì™SÏ([ÿDÆc¾–Ö­í»œÕ¸öÁ*àlëõXnÞ>-’H­".o¶•¶SÙ)ñv{6ó¡“¸…–¨FuÈ×˜?ÞwÐÞqððœ÷þä™ŠÏ>¨B´}‹Ùµ'ôû}DQ:Î=â•^” „;7w;F	*íO‘?un½ÞLæ[¹ò¨“Þšüï“¿ÌWÀoä^‚€ê„ŸŸ@‹¸]G’Î¢ÅÉÿ'ý/½ôR!†Ò[h@,Ñ¡îs»¨$ˆ¼ƒ(q€t’4ÈÅe{k:ç‡B.ÙQ!Aa¯{¶ÃÚN†Öä	Òö­ŒÊc‡Ö÷?wdz£v¼&10q´D4Ñ5e’gé“[ÿ­,O\™JÅÚÚÛ¦SUÞ¾áúºbr•ïKÀH>)A -H%FCõVƒXD$A”6
-5Þè¬bÕx²]ãÕÖ:@mKm³tœ5Þ
-”ÀÑXÌk=;/Ø]éí¤½ÜÿäU.k#ý›O¾×¿ùä¡åóÖÓ‹‡ëbÑˆó?ý*ÿ›|öìÅÖæ?°Ÿçu‹U1ëÁeÜ
-ÐbK÷-‰°,	Ïë­SE	 dîF ®wŸâ1¦4ÅcBLiu~ïxÑZ~ôÒÆ[ÎIÚýG=oÜyeÓÛ·i1u¡žçGñžJ>Ùp7ÿ¨G]S(Ÿ<¤”·ky¶>ñÌY³<YÞße,—9¤Ô@ m¨©/vfŽ×º_XHõÕ´5^ª¯HŒºã½ÁeNž jû6Ó÷å:*qP/‘ î£¢$Ìð\N!q£·i”½…ÅÞÚØP(/-V%QÅáCRšv®DÿmM‹“ÐÄ!‡8ÒMÄ[Ÿ57Ì9}vÑÌÖ§*S£“Gb2¹ì$¿7÷;Z:Ž¶÷/H®WˆÅs‰á“#É¾Ö¶ŽÑ‘š’î¾q€l¿µ­“¿§ €x¢[Aæ X÷SÃ³’Uð»ñdy\æ" Æ]ÔÜ•EŽZžä5Å+íÂ Ê­ð&È²6:2àê9S±r±äbEq²ï¹’§ÃÅ¿_òûµµ¾ß5æé¸$Òéä=‰d×É;ï·XUÁ¾mÝªæêÐÿ˜pú‹¨,ñPL
-a¾<¥âeAj¶ˆÈ²åß†x*f"Šã;á>A™µÐñáØÞI÷ã’äNÖW_ÔwÔ·7‡Q‡Zo(¬;j"þ¦¸¥ÑÔ}²¬UÜ_ú™ý½‘ôär™OÜgŽÎ/w]Î€ž×7bm%.jôN¤ÅR¼÷ý‰îÞŸ7RëÇü³V%xö©ï+<ÿ;| ·¾ldÔö£±í_ÒvêB?K¸ü
-¥d_}]m€Ê I`Õb¸
-Bì3–š•%jÇQ[ÄûvPDqdÖÂÃ=hÞ¦Tõq(%´‡`p÷_¨ZÓV~ „FŸVÑèåÁEljRxD°+-_ˆTÆã1…Hñ¦x%?myqø†ä˜/!'gëz‹Ó-G½¼gëËØ.Ù×ïªé:¼C¢1G¦ê«GûœQ5§¸fëæ`É5oóþ-–¯)Â}¡£¬ÐÇÕÙ£øµ†ñÔÒSôÖq^ó¸ö%êFø}Š‚ ò
-Šs„Ü$¯°žŸÙ’D0ÈýW¦¢@f"@”qWŒ(²2Ô|ŒÐõÚZ@Ôº»j#µ­|‘ÝŠÜãq«<»×ýTÜq–%Þûþg]"m]ƒ—æ˜Ÿ ýƒ£/˜×–‹„Ä`ÒzzuHSÉYëé<6wà´¿È5ÑÙýXÿÒäðze‘kzthm¼6«(vÚÏ­o&‡êKcqûÉýÁðömZIoÁ‡z1á GîÁY™ˆ"ÍJÄ
-Û~?àùëkáƒ7ìWUùH`%±•{î>÷ìæë§Vþpñìµ/uJéÁåÕäo-/?æýÖÓyamýÝ/wùÚ%ÚÞ³rpü™©ñ¹É*Wÿ°ý´¿=à7ýô=‹×ö„®X¼JDä‰Ù($£ù‹¿Ÿ3Ú
-{xVH›v»Ÿ|“´såÏ]ûR—2m&ú7»Ø$ŸÛËä…µ¯ïa“ zû6 ï¡…ÇÓªÊ{êy‹·Ýñ´Í!ýaõü½}Þnn<«ŽÍ‘¥LlpzivÿÅ‡.ÔÕ˜9˜:x`ô™§ÑßëšOêÝ¥nÏÁTâX×þn]N·u•º½c½ŸË³gû6Uó7±÷ÕôÖ×÷ÚÜ{;y3/Æx‡ZÈñvjú£õÑd\Óß“4jŠÖxMŸ›¸ç^4¥wÕô£½üû˜»W{ý{Jz½Óö7mÝº}×Ð—è)"ÍLþ]]¬B””åœ[	¸†oÈ¶®ŽïK÷^£Ë²vG¢©åR¯P¿<4:#wÍuJºUD­hÄÃÏô²UT5}ë¯ë*í{õ2‡@ lß¦‹Ô…QŒ$‡{ºÃµ^TÌT!F@§­z%_Wóx*KTë>b	½%¬·ìÜFÆùœeJO@ºü>_áŒ+JþèØÆi_X6„Ã=üˆõuJS¢·*²_UŠË¿ºÏhIÖuÕ)ÞÅá®"Gùƒ]±TM¨±ˆ8‡ö5ÊûjÂÚ±ß¨;àQ²íõÁÃ³eäÑÃƒCªVªŸô*§Ú"z°s¢Ÿ<zxWê€‘D3ðÂï$¿J*ÜºXµà÷––ÀGcPvTña¦	K9vØÎÎ+gX×ÈŸÆGíz“—›ç?±õ—äBO›Ulr» }œ¼Hß‡€¦œ¼–JÔòëy#…²‰`÷U}NFŠð8ùbÅãôýÇ/|ãˆŸQ<	—]SZ¡ÌíâE;¿›ÿÝs–Šw~mÿ²—ÿŽ™Ýû;——ý/(ÂÏy÷rþîyûãñ³±=¼­ˆ×Ä P8nažH¶~ˆl{xëÏÄkÂÏñÇ{~3ÜAM¨ÔÄjbš˜¢&@MÌÝzOPËÔD5ñ5ÑÄaò.FóãFþÓñPíä]ôŸÂ5ñCj¢…÷åióöí<.o¥&¦©‰*òîö[ÔÄ>j"Ft‹ÞÛù¹ÃyÞª©‰j"@M(6-"q ´b¯à|@šÉAòJééuúŸ…³Â·„·„?#þtAzMúsù‚üuù¯”NåkÊ_(_4\ôZÑ÷‹ÝÅOÿ[ÇS%ZÉpÉ|É÷ûœœÿ¾ô‘ÒY);Yö™²‘—~€<ß&a| ?/óA€hÕ_›ÜÅb _¶ôÏa‚0¾œ‡)œx'HáÏò°ˆnâÊÃjH*Ëh#ÇòpÈçòp1NŸäá4P#;-8‰s8gp8‰S¸]è@'âP1³P-¬‹86¨Èâ,Ö¬±³8aõŸA—°s8£¸ˆUœÂ.a«¸„'óØ«ÖüQœÆi¨»Väã±Ž'±Ž‹¸Œu¬¡…Š#§t*ñ”µÖ%\Ä9¨XÆ.!‹ÓØÀ*ºÐ†ë3ˆC˜ÆÌaÐ¢³›Ê^Ëˆî¡ññVU÷Ì9lá=¹#»|üfk8‡Ó–lg-JkÈâ¨ÿ?J{xëÖ
-V°³x:T, ‹§,-\¶ô©b-¿×d­kë;R(`.áž´¸8uœµ4x	ç1€v´ãiëÃµ—EÎZó-_´ýË«Øþ†ø?: Ä1IcK01:‘ÂÌ VÆ2Zp(=XD3Ü¨‚^ŒÃ)ÀcÐQ‡ ªQ‹^ŒáQ<‚~‚¿0}ß[2s„¼’fÄþEÞùã»@ª'Ú(£•¿%ÊÅ)±¿¨SlŠìÈw¢³tTî¡QÚ Y¥ÆÛÞ«WË®:¯:®*€Œ’Ö<ÆÛHìúðÞ·  ©\#¹¶h²Ä5“¿¯¥rÍüýfì¤Ò\ïºUtDL\[=X°Ë©e:MåÐ:I.k½I¶_fâçs©ÒšŒT
-Àÿ,V#ƒ
+xœ­{yp[Éyç¯û] ’ qx<ðà^ 	’ ) /‘„xèxÐh$€‡$Îèf¤9œÑx<¶B‰í${=ÎÖnìØ©ØÕì±F»Y{g«¦¼å”·v3^»*^Ç®ÌÖº6ñæho<"·ú=€"uÌŒS+_¯ûëî¯¿ûk@  ÊqºWŸ½¬VÕÞðï |ýÔÅÓç¾8à{ gJïé³Ïjß>ö3 ê#@Ã/Ï¬ç×\©"/8sf=o»(¿D¾ åÌ¹ËW/ü­ãÏÈ |÷ì…Õüwloˆ@ç¿pê\þêEácÎ+@—€z>n=ýìÚ€®6€þï‹ž¾,ýWôÖøèÅKë¾ñ|èåó†ßüßADiz "°=HßÚ¾CÛw¶uÔZ*nßáH"‰Ð·ÈãüoÏÜw¨}gö;Åùû±ýè'OäÊö?•Þém2C¿CÒ ƒ®26&²ª:{•‹³L^>f°>?kËæN©›‡Fƒù7l°auU[ñY†”–¾‚T.aDgjîT„Q]htuí¦àñ"™bî”šË%Ô“J‚BŠÑÔ¡«*shŒ¦Rù5&.\½A)Må’,°^à½7*½$Y¯2šÒ’7ÜÄÊ%5†c={ÃG8f„‰:ÂÌ›2ø~Ì—JüêšÊ¾³ÀÄÐ±m¤"5±:Áä	#À„`vé1# ü›†ÊŒ Kdý*äÐ`6«,ìük[0Å7•uóñnŽùC=¥nnæUf_0r~•©|ÌÎ¡äü¹l6ëg4È©U†%ƒa–#˜#åŸejœÍßrb•cÜ’°’Í®å³Œ„³Ùâ	²êó¥´d6Â$]P™Ì¯©LI-LÑ’Ì¦%ý@–‘\„É&»™V×
+ÊJRåƒü¸~‹|þdrnb•I•ÙRê¦ºÉH¸Ð-™Z4rþüRÖÐ²¬ÊË#a?çK‘”StV–
+ß µÄlÓY™–ÔT-™gtå#«Œä˜ÒaeºÊ©­L­Þ±¢òX"—å(¹´I­]¿QV‰ÔD²#°£8åú^ErX«°Æbb0§Nljy.T“Ùðs0ÕÏ;cBPË§­-*1µ,|râa“*¹þkÉ›FÀ¯²«Ò”N°µ|:Âœ:#9UeU©|•UiÉ,sò·%CeNS^.]eN“)ê-«›Zž¹R9u3§2—–Ô"¬ZŸ=dÄµt¶…U¬kW#Ì­Ï.³ËV§?man³ß£P:lª«SŒä“Ìæ&Çh0Y¨â'&ñi*‚F³‰Áäæ¦Ê·uv4Fò%Øoó)4hödYUjŠ9SS9F÷
+ë", n-ÍHŠaì!Ä”–WGtâÁªµ¤:Á*µ$«Ð˜œKªÌ£%Õ#ùoÕÖ¸àF2™äœð¤r|¬à±…ÙÇÃþæl„ùô¼á«Ñ„·µzò¶N/¼Ý§DÞúõ‚ÄÛz½ ó¶A/(¼mÔ6Þ6é…2Þ†u­$&çfšÚÉÈãÜl"Lß5èÛ|ÊŒìí^²U¬*ü¨ó³~Ó:+?èîóôÔp„5ëÂ[M/PÞ¶è·A½ ò6¤$Þ¶ê™·mzAám»^°ñ¶C/”ñ¶SWGLÍíÒÕ«Í©)‘WŽ<·ÆN®¼Ý:ë
+³®ŽëÑUuJ}„Xµü Æ=ü{bøùé{K².TÊ\õXOGA"Þ	£;kž2º‹=ÂéÓÕ~“ò~Eœ‰÷d$üPZx?|<ˆé1m°ÐG¼ü¬º:¢N=‚~†T~0ÂbzgÍH„¾*#©ÕÁÒ¾ Ú©NqßÀhpfssJ›Òòª±âçîWKÞ$Äëéˆ°aÁÇj´$ƒLšh’¬<^ßìÔTuds0Ââ{ÑÔNk=&kÉ¶ÊrÜ¹$›¢*©þ›bHÚ—Mr—kO©›š9C›Ì19u¿Ýæ¸Û³Â“˜Ê­iLJå×&¦ò~&¥rÜåÝ?'¯©*CÚd~Ð¯1{j’‡.{ÊÜ%§>lÍr®r*Ç…!óLz`U&†8AN„Ì­]ê½½²6Râ…ªªL
+y¡FØèÎ³›ã“Úß”Kql‡…ü0§êˆ0o±SåtEÁä “‚3»“KˆÓö¢´4®òûwQ’*‰+Ç3û\qB×ÔNÎÅIV“2üKYCÉvº‰'aã{F—ü{F“û^3R:¿×†iÅÃ›ª:ÂulsðÑ¨LNu²îp„M˜Gæú²8Ÿg-i+¨¦Ž¨Ú`qýI½`ƒÉÒ”ßP¥§þi1?÷c#Ú ?°K_Ù"SzÃáW¦õâá —'´xšÌè^Ëìo€[¸»“tDØGôÏê›Å:"lNgC6Ï¹8¡©êä¦–/q+£s…fóá;¨ß &Ã¶ ß áÀ¢~ƒ˜=Kúbö,sœ©p„â88Ìq8p„ãpà¨~@*a†~“çPáËê7‰ÕwL¿I¬¾Ç8áÐqŽgBs<:ÁñLè$ßs"a9¾'ò|O¬ð=9°Êq¦Ã¶Æq8°Îq8pŠãpà´IW:agLº8´aÒÅ¡'Lº8ô¤I‡ÎštqèœI‡Î›tqè‚^ÀÈŽ /šo,Ž°§,p<a—8ÓÍ·d8ÂžÖ¤ˆsÙ9Î3&)â<«0º³êóÍœqÕùŒç,£?¯Háä/Z Gø^ÀØÎz¿e¾™è/Y G¿fýe½@Š¶@ŽðŠr„èìßYïUóÍDÿ¨rôY G¿®Há·-#lZ Gø¸~£ÜLq™ì¿!RaÂÐþ@6›3Û:Z®–‚u„‡X
+ ƒ‚´'B¼O =-á¨HœÈAQQ©v9%¹.ì¸AWÀ¥ÒÚ»?'?ÞÊ	ŽwïŒÐß»{ È äémHhJÔˆÏƒš¥#4@‚är‰öÚpÔJæ™Å3dÖAoßýÔ4¶·H5}Íè1iìþ4_uz¨}øj¢¼ŒRAª#¢@çÌò+±O!’„<%›‡ ˆ'm2Å1ãŸeŽ#Ñ>ÂÑHžr¥{ Ëó>ë¼ßÙl6áð¶xÛÞ`‹³ÌÞvG•èÀ@´×Wc5^¢D­9Ôß‹ô÷…´fE–Asô÷•à/Ï{%ÿl¬T–÷e†I¥w¦bºIºåP{g{&Ï'äéž¶}!yxžŠ§â±‘áÁiUûuº¡ÞVõ÷uí5ÓÍ[?%cõKmû¦Õ­Ÿ‚óp|ûy“Þ†½‰®j—³J”@æ@i|^$ 9)BÆæe"II‰KÊ¯Ëåry»?ìãT»µX4å‡jb5Š,kÜ*Œ¼PþBýbÓ×Ê¿–ð¼ÔZ•I58B-5Nr<õúë©­;zí}—äÌöê¡NÔ¢£‰a¯‡RBæ ‚P‘lX¬ç^e”
+y™BRÈÔÕuÍu†zÔ¢¦Å´ÙëLbŠ,•ÙëñE{b5²¬QYQLÖÞØ˜yy)“ÿ—ÿÄÌEb‘§J+åäO¯öô;.œ?þ™Å™ädN¶W$f£û›Ì¿:aØ¥ý]ÍaË2·ïÐúÜákß¬$’HŠºVJGç!Š$ÏšÉ.ä$QÒ6õ>ÂH%<Ïû®õþËp«ôx<!O°Ýå	j\PAM–M+ªž;*h¡Ø@IãdÅbù¬ Ï,÷œ?<”q
+ý™3ÑÎr7ML‡8Øÿ|2}jeþµ'úzÉðÝú¡¡hêR¥î=:;]ë'@‘Ø¾Ck©h‚žh¥EùIÜqäEBH’d*+Ê¦ÊÆ/*àÊöš=â“µhûÊ™©æVÎL½87›­°KÉ‘)«q\YÍ}öà³k¹ÏL™‘Fob±1õ;P…:Q‡ëßJsC'„›¯$RÓUcÚ48¹&‡w{5ó‘“¸4* Ô¡.èmqÉö}ÜÅ}€×S4tÓê!~$ã—ãã³r_&*…Ã£Ý=ön*>?>qpRÕ¶¾Kzëºú‡G¶þÝÛw¨—:Ñ†ÎD¸Æ'PÔ´Ý’j Bž;ì¤À-·­ÁpP2M¥5æãöÑßjmqÎsµPBœß^¯¦¦‘z=²öæÅæá¦Å¡ôÁÖ–Ù‰CÊ%ó1×T<9ÙÞ:Ó_:ãèíêlõw¥rûÐøÁÃí¡îº–žps½ìP|ý]s»qoR•:M»ùúëNJwŽ(–˜É•˜æAi’ó1!Ü3“µ{â~<Ïû®õþËì2œ6O°ÅÉg—¨LjÕ;º©””óãÏËéÉ–ÁLí‡Š÷Lgë'„-¦d@¦®äm*Â‰ÖD‹@K˜8i‰rÄ¤Î@‹‹²¤J<‚È\ƒ†Ždj¤c2SaDâµ=ö7SS™:ÿàèÖ?ð=¾£xê>±pÀÐ ¸{M8¨h1rÔ÷aß+¯¼Âçp½@o£D£(PBâ\·è
+gž¾kL/Ì)rE×;sG…JjE6÷ß¥ªzöïO5TN-¥Ý=+Ù3Ç«÷ÓÛ[iƒCÝ‡ÉW¶6žþÐþl¶ç,¹R²[üŠ¾ƒ
+Î1ƒ!£<à$w†#È8ìŠŒ
+R!Ú}á¨µSTðz¢QååæáÜüùÊÑŠæ†²*úÉ»EGºèÃµ¢.²×«È.]¬3uÃŠâVà‘ºÛƒ@é^â¾WyÐ…¿ÇJ`®‡àšØX7Üž`qØ}~<æÆ_Ú«U™#Ÿ}”?v÷Ý¼8çrûW´ÚQƒH¢ÃF¥„Î•z€§n'yê6Æµ iªNj¼<#BÍíïk•,ÆÊˆ’®X¸¯Ÿœø£ÇB­bßùr*n—•ŸØœŸŽùö/.l„š+jÉñ”kû·ïPµkðÀý’æ9AÉÎý¡QÒ²øgþÞk½ÿ2÷Â}>CÑZô…Ìð}R"­Ù]>c|€¾³õå{‚Úã2tžƒÀ¿­Ó&*BÃ`¢ßFÊóTBçDK>‚@V@È—””ç”OšYœ†fOÐ2“_kÌÌ•v”‹‘eÅ1ÓŠeY;44ÎÎ,Wx„Æå‘ñ9¹7Ó#éfxŠdŽ¸_^{ªo`vÙŒSµmDßú«†3N‘Ê»ïž?‚£ ýmzÊŽ¡'Í,sÇû(P\.Ó«Ask±€B>»±´ñ¿4ä —î~Š^šžÆ®˜þê¸o fP·ä´}ùéGhÆô¶8¥½"Ùqµoe†Œ¸Îù‡ÇÜÌö:IßB=¹uµe6±èšLë·ÒÔ{1·þÖ`‹sKFkEYeOŠšüäeãXÅÇÀÐÒšÛiKNM…ÇÃOeï®üèÇÒµ}Ã/\Ìu·Í›Y,oß1å^‡+–UT[‰:÷+<s¿ç¶|ÅQ±†÷øª‡Í{Ô”l6û-—'èÕ¤Ý9åýê¢‘ßyKdLí4“Á­ÿ\ä(i¸û.^#
+ùO$	?8/r9Ÿ¤„€Ü˜Ü±€òZ%i¬$ÊÒ’¥­€›ÊÑØ'2Çýn|¾#\nWµhßvk‚æŽò ýµ²>÷Ì•WÍ'=v÷ËôöÝ/Ócw'-¿w‡Ó· áÆëU•T¢%¯Ó	¢ ‰§KùÕ8×7äå=¼n~–,X¨{øþ~ë}¥¸÷±»\îP§ù÷§ù»4Í²ïÎ—¤ÀìXö±¡O”4nyÕí”ŸOgeŸ)ÿÉÐÜ©XüÚ‹%­{ñb®%ò''¦’[_1ùÝÐcô6ÊÌ»
+A¤ÂiÓˆø¼DÌº@Êxh%¼Åü]Ï×[_h#SŽ­7úéíé_LoýGsÝïo?K“ôWp!4ËjŒD9ÈG¹]sf”qœWAÈ³ÙoÔ¹©½6\=0‹ÊE;ªÑB¡þï/|döð“_ðTÊ‡'æÇÉÔþ´wæW·„Ö¾ýÛ‹æ>íÛÏ’×öî‚òÜ‚˜ûWììYVvÊ‘Ö¨Ïç%¯Ý·QëQ“OÓô6*P‡c³¬uÁHø^1RHt²Ì/Qî©©™H¢H/)D‚.öûq²	gUe­¯²®ªÎåòœ6»?ÕÜÅŠ—+xŒKÙtnšðòÒ3ÿ÷ð‘«/e¯\ºÕ—¶ÉB´ó«azÛ˜;óœ²õ_Ix2ÚÝRímïØÚ.ÉÕ²£®„þ \!ŠÒI>FÌðQŽr.\;ÒUJ×3äÏ[_n#[…vrÜAoOÿÝô/‹~›×+qzÍˆ&ºÕ&—“J‚È'Dˆ<D„$Å¹Š—¬'¶8e{}˜î«V	³“û´º´kë{ãróDÏáõý/Ý¨ŸÜ—ž:V.&‘15mçéÓ[ÿ
+®,O]IG;»:gÓµžÁÑÆ†2rÓ(`¬hÿåð£éÄx°ÑL= Úˆ$ˆÒF©¢ŸWÌŠV¶*Úúz‡¨o¯oÓ¿cŸ§å°·”ñÊÖ²ÇÝuíŽYpÿYL²66´ùô[C›O>UíV>tÐ|:übÙhƒ_´9~±ñ“/ò¿éçÏ_êhûëù?=.±6j>8; ZfÊ±=’%AàÑÔ"J !w¯Šà2ôZUD,êÖ”ÖXTˆ*Žïž´}¯ý¯l¼á˜¦}Üÿ5~G0»}‡–Q'yÜóï³—í‰{éûã^#ZƒÅZóÏŠ|l}ê¹óFUªj¨7¹\i—ÒÃþÎ‘ÖÁè¹¯ì?³Ü×Ùrdq¤±:1îŠ–ùòµÛwhˆ¾…—Q¹‚xˆµ‰Š’0Ç}¨$Bâ
+l*Ò8W`!“<½£¥¹Á_UQ¦ B"ŠÝ&;Š¤´î\")¾‡êš#Á©Ãvq¬/Ÿˆµ?1ol›~ÑÈ7¦kÒãÓGíb*µì Ÿ‹ùìíÝÇºúG¤Ö«Å²LbôôXj°£³{|l_yß 9Ûolëäoé;ð#–è“DAùœ ˜Òè¼dÞÃñ›~Ó(Ë“2gû\ÕÍUc³×ó‚¾5Vc]ÅËAóZ‘§nãcÃÎþsÕ+—Ê/U—¥_(¿*«þýòßÜÖÙñvï„»û²HgSOö'R½O¦î¾Ý5læßMÛºY'5 ™pølT–Š©¥›QÊ”Óó6"Ëfˆ2óL1¯QœÜ¹fAÆæMt¼7¶ç®ûA—äñÑÛØ4v7vµ…Ð€zO0¤•Ù÷=˜ôÞ«¨dY«~°¨2x<½\é›ŒñƒË½ç—‹¥•ûåõhg¹“&¦²Ž2)6À“á‡^L¦×Oø§Ìëü)Ò8M®ð2ëÈÆÊ±qË'F·I»¨Aü4áô)”’¦Æ†z?•AKœöÃ¬½p„X6–ž—%jÅ‹ÅM;(¢8ÆïÖM]ßƒæyÿ•j?ÈJ	í<‘/ÝgÍº@-^­ºÅÃ…ØÚªð›ë–I+^:ÕÄbQ…H±ÖX·6¼<zS²,'§âóý-‰ÅÙö£qïÙú<¶Ë›†œû"vÏˆ˜Ì™ÆºñAÇ¡ÇTÍ!îŸÛº/¿îiÛß®E-Þ&Â}¡y×a†1žŽÝw<!L>³ô½}w’ÓÀïG>G]hF@T I>…²!·È§X˜Ïl/Æ?Âˆsÿã‘©(9…%AÜ#læ7Å¡ëõõ€×‡ûzëÃõ-ÍÜŠu3FpŒÅÌ«¸ûÝOõ½gjâýïpîøéì_>xâÔÁ)2É¸¾lñ”ùô·K3©yóé8‘9pÖgsNõô=>´4=º^csÎŽ¬ÅÉk£ÑêªHõÜújj¤±"³žÜŒnß¡5ô6¼b µ~`"xäŽÏËDi^²JgŸð}-õðÂò)öÚb$0“¶š=7½{Nó¥3+¸xþúçz¤–l|y5õ[ËË;Ääþ)óéxjmýÍÏwý£Ë´«åÐäs3“™éZçÐ¨õ´îx­ÙCß2iíJèŠI«DDžhRr1^,=}>Nh{0äæ¹j)ÝkÝí¼ò}DÒž•?\¼pýs½RÐ°ˆ<qæßï"“|b/‘O­}i™uÛwè}í<žÖÖÜwwkÒ¶;ž¶£-¨?êîöþËÛ¢ÞÜ|^cK¹h|vi~ÿ¥‡Ÿji<4<w46<sèÀøsŽäPO´÷`Jï«p¹¥'z÷÷ézdj´³·Âå9”L®ó+I(Ûwè"ubc‰øh_¨Þã–lÈ\5¢tÖ¬¼‹ßqÿ+KT“f0Ž„ÞÒÛw¾/Š•â¿y ¥•¬^Ÿ×[Ò	E)²Ú:Œõ•Rs(ÔÏE2Ø#ÍˆžÚð~U)«úbS²=ÕÐÛ xG{wlöªßôFÓû‚-6>âˆ4µÈMûBÚ‰7p+ù®žÆÀ‘ùJrüH|DÕJCÓåLgXôL‘ãGvåðvøN´A ¿k8Í¯™KÕNñûKŸ§¢vØ[²õ¦©Üš&¸Íc¥]<!¿zŽõŽýYlÜÊÇy:~ñC[?$OõwšÉ8÷[D¢O—éÛÐZ×Ò‰z^ƒ-]×ì.Š2Ò„ûÕ—«Ÿ¨¦o?ñÄÎýéO©î„Óºù6]ŸËÉ‹^ÿî‚1OÅ»ïZ¿Fæ¿½¦À¿¾¢|ådÕÈÿ"üœwÿ7ÇïòßKãG“çÿËöè¶"^OBá¸¥y"Ùú ²íÑ­¿¯?ÇŸìùs/5 R¢#.|cäMŒS3ÔÀ 5 j AÄ©njÀMÞÄ5ðmŽÃçñ’Ô@?5à§Žñ3ÔÀ25ð5ÐZÄé¢¾O´á®âºcÔ@50KÔ’7·ß š¨(ÑÍyß.Î-®_G(Ö|"q: tà ãIŒ|’6Ñ&zšþ@hþ\ø{±LL‰$AJI?”Ãò¢ü;ò_*CÊQå%[•-n»`û7¶_—EÊ^*ûk{¹}ÙþF¹Pþ-Çºã%Ç§+Ê+ò7+Ë*_­ü•Sùë¢,zñ=4ãIÈ ø	á“ ùy¥D3wßäÚ(–ø¼©&áóE˜ÂïaiüEÑGœEXÂ>’.Â2:É‰"lÃùD.Ã)òã"\Žfš,ÂNá.â9\ÂNã.CE/ºÑƒTÌ ‰y¨&Ö%\D'TäqkæØyœ2ûÏ!ËØÀœ‡Šq\Â*Î`—±ŽU\ÆÓEìUsþ8Îâ,Ô];òñKXÇÓXÇ%<‹u¬¡‡Š£&_éT,âs¯Ë¸„P±Œ\Fg±Uô¢Ýæ'ŽÃ˜ÅQd7×Ù½ÊÞ5–Ù³ÆÛUÝ3çˆ‰÷ôîÑñ›íÄœ5y;o®´†<žƒŠÐ?“ÛóØÀ“X7±V°‚œÇ“Ð¡by<cJáYSž*ÖŠgCÞì±°6°¾Ã…æ.ài“Š³XÇyS‚—qÃèB®˜.½<:qÞœoú¥í_^Ãög0òÐÿIÁ¿=ëÂpÓ˜‚€%,â–q.šÿW"‹	G³Á€=è@;Êá@?ÚP7<˜„38€Ç¡£~Ô¡xQü?0{ß]2
+„|*Ëˆõ«Â‹(ÉoéþH‹Œþ–¨\gÄ![Ø.úÙ^ì<Lçé¸ÜO#´Y2;+’ßö\«¾VyÍqÍ~Md”wàN~‰]Þû ]h!×–¸nð÷µt¡¿ß²Áê@:ë/´ò®Û¶k bâúê¡Ò€•Ž/ÓY—£4L$¹²ãÙ~•‰Ÿ,P¤oJk2Òi ÿc¤C`
 endstream
 endobj
-
 150 0 obj
-[/ICCBased 151 0 R]
+<</Length 2424/Filter/FlateDecode>>
+stream
+xœÕ[moÇþÎ_1qãÔnëáÎì;`ˆ•i-, ’|+6@Q¶Â È¿/fïöt»Ü=J,d·_tœ½}yfž™%µþêfÿîòb³‡/ÏV€@‚gòð‘asµÞ(Øü
+£‰Š¢“OÖÇÞÊGg¼²~ÙìÒÀ+pÄ `›ž2Ãvœi»z»º\ýkõÍË³u^óùóõWûýÅæí›Ÿ¾_Ÿ_¿ÿqýê××ûßß¿Yûæâ§77ësùüÏ‹Ÿßí.öï®w_~ùâë³4Ã«÷»çÏ×/Ïþö5¨¡ù8ƒ¼p¤óçmþ¬F£¤Á•òêíêß«Ýê(T1:VJ˜ÉÓÔ3…GCä½|tCI#¢c“JYT¬F¸5j=Š:8Œš0IŽPiØL2k´!$b´>Ï:J0‘ÃôV”®£Ã4šÐIOÇ¨²¸ãR
+É‚±
+ÉATèM^c6 ½FcFQ;BR½ËÂ´ï$2YÔÃ ¬z=éb6i9}ûÖfBÏ`œFf H¨Ò	u@šä-måX¬†F+tqTkZ&ëx³zÖz$ O¨\µ#PŒh"l“¨g")4"£·²ŽH±™F-½•Æ d²
+Ý S2³d§g²U²loD$º¨eY^Ì5œd”VoÁ™ˆÎyƒÊŠëy/ãFy›eÑ’(Íy%²òèÁ9‡¢À€žÀY‹.diN'˜ä·l0ŠÊ‚è<Kb/+}G™µ<œ&4	‰>€³ZÌ5Jp^aäé­wh¥¯CÓ^½ÒJ`°¯ey^Ä('w!
+ÌŠœeYØ€#ÂhGÑJÿ§~’ò‚èQf2éTâ;v £g8Ô(ÉÆµ8¿&—ƒø¤l”¸Æ3YF$#ùCYŒ4˜‘£xc°âŠW@!ÊY–Ø1€J°
+´Ì¥`d<Ÿ.‹ÎÊk£1Hp6@†Å9Å­7ÀUkR[ ˆ6‚õ) 8´àXÜÄŠþœœY%ˆD$±À3Áª
+Æ„AkÚi:&( ËŒ6ø VPÃÌ¢ØIP­"á˜XN£¥™€ÈÊî4‘˜ŒÈ§p7Hr¼˜Î o,¡½ím5jŸ$-RŠ/2¯r\oe.¶F¦Øûˆ"&ðqà2LH±(”€A{sÒ‰”F#Æ1¢eˆ.!&:)2Ò`:J¶ãldÃ˜’‡+*PNæ	<ÀÑˆ ÉA0ü7@ÃË¨eï¬”€:¹”K’éxAô)²& à$ˆÈ@-Ê÷2Q±ü&ñíã&Nýîâ÷ë_÷™8'ÒO4ç!E•¹îìU‚Ÿ¶“OF“ö,y@°‰ö<¼:û(´ðx9æ&0
+X·«WãæœM¥­B«YtÆ³Ã’²Ò‘É
+årÚ†M<»zq
+ÎoÖ—
+˜àüržÆ(8¿úþÉJ©”¢ñÉãSOSµÛª~ïÆ§/ä×E¯}ú»ÚhXárö&·ÝmãÌäç£Çw³þyt±
+«ñ9î—ÇsðØ÷éç_}sÞ0¯¿»ØýüäÍîiÇ"’[¨*ñ¹—AÄ—L2œ³ŠÇ'Ûâh»ê`ùÀy´/ÚoN0›ÒªE…Âós·´’¦™¹³1K(ÍmÐå3é”¶¥Mg·Yã¬ÚöNÙ…>À‚¶RlGóà{À!#XgÐ’•ö·ª„ò¤ÃÉ?›+óQ©Ùa²?ªóQ_¦í60*mÿ¿p]5|^‚ºÖA>pmúe=ž£í¸êfÓë–ç¨9”›fû¢åé\E×?.†ì'¥ÅîÃoVR¯[Ó=¿ÙÎÒ6¢WîdÔÐÑhzŒàl3"¾žSÑØVLAm­Þet¼l®Ú&¼Ùm9¦n­ÖÎëL½|Å3e/˜!#:¦‘ƒ¨;ÅìÚ%³}ê]e«íå*¾SE{™Ü®žwS1Ø(7u=ño1óK¸Æ£Qôƒ|¢ÕJ¹“©›¦Þ–tÚSRm¢ýl®Zu%LsTsÕ|Ù( óºÓzQOÐpèóÚóÝå9ª¬°Âèî¨ßÒ‘wˆÝÜí¤µeÆç¦»{:5ÏFí‹Ôì€5{¡r<Éî¸#øŽ#°EÃÃûZÕÎ….Êð^¢*íÌÉlU¿¬QéÛñ%¶ª€6&¹½žç°eª¡çùÇ ¦Ï¦–G³Lg:\YÜ*®Å“
+jµjêC$´!b¢Ç¨•\üï¤‘w/ŽOÏÁLˆÅÁ$	‹µ½E§è&a<+Cê+†:ì´!ß"§Ï[Ñûq“.\t´"l#®nåþé(é£Q~½¢º)”yè^®™Ú53W@UHUwûK”Eªã6 Gÿ€¾ÁsÝL™“™{D3ªÕXÚðq‹ã—Ìq¼’©3ãvÝ’£è¼¶©°2^YŒ4•ôðtlé¤|žÇÍº§J«jß5×Îó+N«ï¾>’íÊ»¬2	èÇŸ\w.–Q£~@\wJÕfé;7c™Û¤¶?õC‘^×‹4X Ö„{Óäs wÜãŽ¥móBà Ì×‰—ï\×)WM=Õ^ò<Àt'¤©Í]«:[Mq…ÌˆmÄÜ1kt!žž-Þ¹²®’Û¨ªv§[½Wµ•ššpuRu}w&XN˜¦³—H{Æî4¬vª·b:‚Ö"Æ5t}u{4•èµ7ÓÅ3œüëþ•CN¿s?ÿû¥[ÖÉp}×Q_ªp³@¶ÓíÅ‚¾:ßQè QÒÛæ
+E„Õ¾4Î‘5W£xy{÷H;¥N™Æ%éÏËNNÇÆ-–œê% ÔQ­ÈO×tK›Rï*ŠÔ7•­4õ/³¦”\I ï|¢C¥ø¡ þì.š»k
+Ñ	™UÚ˜U9U‹7úWÄœ&Ÿ¶Jýå²öØ!j4b[™IÚÓØèc\4ÑÍŸÜ1÷mvoÿYpŒÎw0Útzõ\nÑÞéº¶—öµÒ„ÃÔãÈÐ"Avnè5[tÿ¯²Y[Wõô±äã¤ôî8Ù9íîH9Û®¦JhÝzZÕÞ©,³òÜ/¯=³ø%C‹Ž±­É	Û`]í´òþNìèêvöo´
+¨éÁòhÕ¬×òÏ‘Ô½@•¾²©åæÐHº	:Óûƒ¸‘^_Ý+p¥•¿cé`³MÍxq½ß__ÝþÄ_¯¯÷ÿñÑ¯}â
+endstream
 endobj
-
 151 0 obj
-<<
-  /Length 314
-  /N 3
-  /Range [0 1 0 1 0 1]
-  /Filter /FlateDecode
->>
+<</Length 2452/Filter/FlateDecode>>
+stream
+xœí\Ýs·ç_±žÔ‰ÕVKìâ»uÝ‰•tÚNÜiGšéCœ™‘bw$Êa˜éä¿ïà¾xÀÇEÒQíÞw »¿]ì{œ¹Z¿»¾\¬áå«³Ù@ @Ài¸XÏ°¸/,~^yAÞ„;mœa«Ã­QVh?-–UÃ[0Ä à¦º†nšžnfog×³Í¾~u6oÇ|þ|þåz}¹x{õý·ó‹»÷ßÍÏ~³þåýÕü¯W—ß_­æáþŸ—?¼[^®ßÝ-_¼xùU R³C!¥k2Ü‚V¹)Ý´%Ý”º—ëŠÙÛÙ¿gËÙ PE‚µ©çÜ•m:@Ä^Ynk†PÅ†À¥+>°'ÔÞÓènœG'0J7@Î¢·:	ä4é@ 9‰Ìán¤,*îo€”F£ª7”DîP)FòÉÀX¡p´F+C:m €*ïÀ0F¯‹BÂ"pÀ;`á‘n”g§”c`R(4yáÈ‡~µ³4Zá€™ÑS —(HáQº@ 1:v Ã"ž¡Õ@dQÛ®æëÑÊ®âHS©k %JSe(jT÷®}˜¾ÕU‡¬Z7ÀÖ£SÓŒ¡Þ1ç€•Ck€«ýJ!©ÐÞ;´Ö	‰*`†½GM¼AËÀÞ %TI×ˆZº‹ÙÛšú0$·àZ
+|5¡7ÇU‰„
+¥ðr`…S¨\˜zóØË0q@,Ñ›ªæ&ì£C…È$_5–a~dCo	!‹Jßj;¹|þ|þêìo_hÕ¨Óu£ÐeƒNr FîNI’V‚@Ò3é€|u¬+¸Ï^^€€‹ÕüZ ¸¸î›·ß>{-„x-XW×e]"Y]¯«ßuT·ŠêLsµýÖBU×“^Ý2Ó‡`n®ýÑÚ¾º§]9ô,^¯O¾»øûìë‹¡±ªÌÑ7—¿Üý¼.ð\ÄÃ³óJÍu0á®b&ête=,œŸýjø/(xÕØPåUÐþÙyF~”Û8V»HOŽHOPsmx&d$‰M½NÞ¯žÿ6b°`ŠÊË¼8"ˆtu€}˜Ôm×õ÷áç´®‘-u6½Æ²î³™çß\.xvµ<)ð[[4ìwå7A°^»pœÎ·7ÉÜêço¢Ú7}¦u-#ÝjÛsÙ«©Å±*óMØ%j½+·xœ[Ÿ7bVÑôT$üxÒë‘Í¤;dæ™©¢‡1¿6Ã½Û¯®m–ðuFb6!³-Ç2oëc»ÚZà–²ÖFšI}®öÅÄrý(76úÐ¶6±ÕîÏ©nóEiƒáË`V0“EVæ@hîf‘Î4áSÂ”}Ž¬bãÉïúRhñ÷Ó±¶íŸ:Ñ~›ÔËñç©Ž¥y¨>uí¢U+¶*-qnžf`8T­Žm2»òõŒ®.CSç¡©½B2¶MiC”¼Ž
+—ÆdªpcØMDfÌg'ÿÉScÔX|õ9{Ô³o¿Å|·5jSùOû5ÕãÏ¨ò®_Õb¾ÓÑÈlùøáølþ~þ8 q`Ú§®*%»h}¢ýû[9–y+ÑÍ£¥#ZýR*ÓY™[Bµ5èŒêP+ÀÀ«“"¾¶&c°¸éû åõ²<wW°/!u*aa|I9‚ö(‹ç	Œb×jûã·ã7q#K0,­ñ{Øãðj ó¨v5¡a¢{.ÓÍòœ†òñª›•¥ àjÌÑ`ÖÎEõ§ö•²šPa;EK…^èck	QIM†ôìQI0Yìl" AûYƒ&ø~ FTx5êïF®!4zÞin‹ú¿~ðz—ï!QÜ¡£™´[çyÑQÒ›ï“Ýà‚nDÏæèº!Kº1¤gºq(/¯§Vñ{|ÖƒðH5Û©dG]í8ñ0Wn´õ`EAn!ðWžÑ«£GW¤ÈÍÐ³Gä¾è‹2õD“õs‹UM£ŽÃ¤=-õ;ïWˆ1'¯ƒ_2·ÎJi8ÔÚÎð™ø,…“Æ£ƒ¯eèÙ#øþ<«‚)ØºÁþËÞ†c…k÷´ƒÓ6TKG:1l£ã»†SÉsì* ¼[*éÐyõ«<Âª<Ü'ÍìEßeêdÛçòÄcÎá‰UC;Z‘ßrj¥H 5ú`§V$SEÜñ«p`ØµONn7¢Hž§ã5ð(Â:é,wt×•Ka]†ž(¬›¨ÓŸåúSLøAbB.Ä„Ò´âèž5—bÂ=ŸbÂ:&äBL(•FËGwË¹fèÙïÑD!xúÊe„Tå$‡LEtÌ”B¹=+”;’#ðáå¸;Uy©!›öÃÄN©í6QòY"¼nö­1SÒ4¥ní@&Û³ËÄX˜õÄ@_€‘¨•|pË[”í†ÎZQ
+Ã‹¯íÊ-3*ºÊìLŒùSFÛ¢TÅØw¨K§Y_slƒd§x3J¾ÿÞwÉ	ž˜ W'.i6¥¢[E½ÝdåÎ¢rF°óñG2:±0+ƒ¬>ÜE6™±µâžüÎ¯+ie+m=Ääª|ÄÿEþ„¿AÙõ}üØjzqŠ{²ÂÔ½>If—(~ë%ÉjÉîörÐñF`ÁÙî«N¬@“òð²’¾¿"Œ ¼RÏìÐKëå,ÎÀ?H³Òšç9ë™úã#ŸQ¤†2fœ	Q
+ÇZ¼=§ôéöL¸LôPØkÚç¥‡ã	ÐÚÑ’ƒ üþÒé›»qÔ_MsuóÓHÒ¥µn‹°tò™‹˜€õÂþ¡‘ÒjÇc‰×ÊªÝ²&gÓ5?ïN·º,	2î°%ÎIºÏ=í8HÒˆ¸Ÿcs¨ãï1Ž€JU@3ôûñ$•WŠQo_~ÕÞ}– òÜÉ„Hu¼6Â¥T÷,EëžñP'VÃ…nºâ|4›ÌÒà®joüÑ·™¥+Á=GÑñmö~üÁ}8uØƒ(8ž«é>ë±w4¦„N#ZVú˜€Ø#{y°	U$7òYdaGˆ„CIJ?·W•$ò$ýÄ–ÿïŽ›Óû{›Ïð&X‡œ‚]gQJïÔ¥¥lƒAë îS.å!s)û½=ÍèMõÂo¢w£³ñŠo²ù/¦—wëõÝíæï˜þrw·.ÿSr´mÑzïÛç ¤ƒx´Æ‰|^å'Øó¢ý¶noRóGv}ñ¦yÿDjˆ¤Zš7è[‚öÈ{ŒÔŠÅÉš‘'};ø?KÐv
+endstream
+endobj
+152 0 obj
+<</Length 2589/Filter/FlateDecode>>
+stream
+xœÕ[Ýs·ç_ØNk¹Ñß3ªKI¦íÄv¤™>Äy3vG¢…™NþûŽ»Ü‘´i'/¼Ã€[ìþöàüÅÃúíòz±fç//f?1Á8ãì4^\lq7_p¶ø™q:pl¼3Ö[éL¼µÚqØÏ‹U7ðŽY!g·Ý5ÎpÛÏt;{3[Îþ3ûúåÅ<}óìlþb½¾^¼yýÃwó«ûwßÏ/¹Yÿúîõüï¯¯xý0¿Š÷ÿ¾þñíêzýö~õüùùW‘H#=p¥sNƒdwÌh²oÝ¦–é[¹óæÁìÍì¿³Õì'Æ[-¸4v³æÜvô„Zçâí†!¢cCdˆ6d`‚gÞ€ìŽ	À+Ï$(Ën™ð‚óŒƒWLxVyÆ™ð
+¤Œw&´mãý-Ú€Õ]­ÀÇ;ÐLh	"x&@X¶`R÷žNÅ1LlºH€° ƒgV‚`Â@ÐžY\±Eä@ðLò B°ÛÈ¤×ÚK&…e•µL€{˜Œóï<3à¸gRJ"Ò+"(<S<€ò‘ !ÁKÏT|!˜D|/8Ã„p`\nÆõp*?¸eÂˆø¥<À(PvÓT±i€‹Íì&Äå;ÓM(§Ù-“.€‹K3âs/ÁzÏ¤öà,“‘Õ‘~­Aè8>xpÎ3ÁèˆáY°à$“Á‚-¢“®åéJ¶˜½ÙP?&-Çî˜çàDä«³yÙµ×±;GVxÚÇ¥÷¯ƒŠK‘œƒ·ž	© Ø®×ì#£ãÅ=Þ‚Ý`×'\œ²èôm£q—ï®Wggó—ÿøŠñ¤FY×­Ïœâ`@`÷Z	åã ¹
+R˜ˆ{ŸIÓ}v~Å8»z˜/9‹Ò`WËÒ„pvu÷ÝÓWœóWœ‹þj7WÅñUÊþ½ëÛ}¡âõóþ¥Ž×çý›ÍLe¿<~]¼[õ_ÒxfÉËI_qnÐ¼™’ÍûÓbÚ<$M‘†ôS?”}šæ—¦¶À-y©_&C&F)ò¾{þ˜tÖ%òŠñ
+Wèé^<“éãHy	¥,Öh†u¥ÿúÖªl2Ô(HN¾¿úçìë«
+øEü"Zw4ð'YfêºìñÒ±ðòØ„µ¤@¢½\Y_®õdáà&Ô.ºÞ€ª$KÈm‡žc5J,Ä˜Õ%ŽúqKÂ îë¬o ­šºˆJfºÒU•ó'ÅN–K™¡Ø"OVÈëÞý¥ùEüI´«¸½¶…®B7„ÕGÃxOj²¥êg›·Y`ÒÓÄUY³“ænÜŸ`ûBM.–g?çßJŠ7Ó”F/»H}uÍƒ÷¿o9aù±aËn³ZÝ@­Òàí±@‹,Œª;ósËì˜“Z÷Ÿ¹©hIb6jƒfp`pMÄ$ü	rØØ®§½ˆiˆ&Fç1.ÝÊF¹˜Æ$±ŒõQ4:ÞXéwÍF2OO®þW§Æ¨q6¦r> TÎ°ÅÀ–ã“êk5>ÅÖ·îÞÚ6<EëèÁÚ††«CÃžËß€F…œãä6D_õ0í¶ë4Lù€13õy%´{¨NþPgÝ>‘„©¼­­š†çÝÛg˜i(ÃÄõÙbWSÈÂÝãq#
+
+fX¥cçàÞ6M GÛu%+Y"yªƒºôÜ”ý%fMQ:ìŠƒß^ÿzÿËºÁ#c..»¢›‰%¼x×1KF‹äMWËsìòâ_,ªúÿ™f/ûŠ¦öt¬ÅÍ.k	e£œb´ ÅÍ§29{ÇÉX†4–ä±vÔ0P\Uê#ËñØ'û°¤iµlc ‡-Ã•ŸK’Ê‰Ú¬=õ$ÎÊF‡Ômp\Õ÷"˜–ÝhZ¾‹4ékÝ]Är'+UHy¤ÀÒ¨°˜X£æG+/‰åBFÑz§õ—®a5â§L%ÅãêTJˆqcÚÅ0*Ñ'üÅ¶"‚}\,ÛÕÊFÂ‡q¿Ñ·TÌ£05û1+E?ËMÝÁî ÜF­ÌpöðJÙpÀæµV‘Å•Ýä ª…–TF¸My õË#)Éi…ÑT×þ„D@(v@¥àÉÀWé„U’F€ç«íï“iQLEv-o@õ¥U	Îàr¹ÊÅAí¨ Ž‹òaiÂíUaÙB„…Z>ªõÕ§+ÄXçœ)Õv”S—‹]…òŽé@j·ÉÊ°ãÈ€Áß¦ëCªGÂŸ©ï×íq=C¹mÕb—j7¶Ëâ…Eí$pŽ SÚÅ>˜m¡1™jW>ï¬×—¯ãÙ6î$ÆÁñÿ¤Jîhßêu#q¯V(k>dkhP”#_é¿^fEÈµîÍO(ƒU’âa­â¶gaa¬l+u[­-{ï4O[ý÷Øø&‘g=ûÝ­Š„ivcþ †§–¹«‡é¢Õ®‘H=BÇYë–{‡zŠK·æ©OÙÑ€P²ˆÎ¬,e4™˜èˆmèˆ«ÕGóG(L§í‰ xõ½qyo`ƒã4ÌØû8ÕY)ø}åô#(olÓh¡Ao_„ì?ä5ðí>îOCˆÑ=ˆFtU"Í*ˆÖ>‚þì´ë¶.ÿJÖ`ÆJ´Øš9b†ÎsÊ4¼Ó –jœn:È¨û:ÜUpÝ‰×£òª
+!gòc¡Zc›GÙ á8{<Û8Š†HÄxÑœŒzâw:|ÇFY±]îQ¶kdc»FiöhAñŸöÇóº_OLÚê|èè¹PzÜ±¶IÔ*+ê‘1cBYwÐ™†×h…ãõ0ÆŒœÕóo¯W?>}½:i`Tj0ò`o-Æ1ÚÛ©ÓNç'Óü±)K[ö°î.”/Íû.xÊ^#¾¨¨Ü.Uùå>Jx>í»ä°@+•^çÆä¿Qö9¿IÃ²Úþ­atO/öŒ£y
+ÚÁYäIÛ=’“°UO(WÐ ¼áà”ON¦|4ôJ×¤q¸œ›Ã»Æ¾@Ëà’8Œ~%(6ÅWˆÙlÎÉë‚Ü°îçJ§›S|pmë0ˆ(]ù¬I{æ'³Rkd«”ÓBAg¥O¢4—çÕ„\F k& ëâ	ÍÅñ û	Ø:*èî4ýgñçQ‰¦Ç:EU|€§Ê¹t‚é¦¬RÑ–Š¹,â:Â†nØŸGaP=˜“TcÃ·$‚/'eÏg%x^ë£|âø³ü/‚/Ê®xÔÉ[Ï‚’ªÕ@¥SŒ˜Jò€±$H;e£„áÇvã¿eÙ(BF :H£ˆÅ£Iÿ €ÑƒRžÃƒSÙ—º2ˆ§¶…:ÚŠÄçÕ.‰x‰o†y˜ ÐÚ÷H+/a•z/wàÂ@ûÓêqt5Ä(1§Õ?Ÿß¯×÷wÛÿs¿nÿ×˜„à\Áû™£BpÖs|vp¯ÓÓa‡sƒãAÚ¢ã;Dj<	o|€Ê6)¥)¾yÁÈxüòHœìù¨<ƒþÆsÖà
+endstream
+endobj
+153 0 obj
+<</Length 314/N 3/Range[0 1 0 1 0 1]/Filter/FlateDecode>>
 stream
 xœ}¿KqÆ?×U–X94%MQKS†Nø#Ô¦óüQ vÝ÷BšË¡©hˆFk	¢ÙÆú‚ !
 ¢­Õ †’‹¯ZPÏò~xx^Þ—”ç¼QÝŠ¶ùµx"©¹^PñÒÏ cº!ÌåH0
  ô’0l+Ï½ß£Èy7½®Ó;¯×«É¥º;QŽ?V.ø_îtFÀà3LËEÆK¶)y	ðëz”80eÅIPö¤Ÿkñ‰äT‹/%[Ñp ” å:8ÕÁ…ü¶¼+%¿÷dŠ±ÐŒ"ÂÿG¦·™	`d_¿{Ù¹ÙÖ–gzžçm\‡Ð8rœÏSÇiœúµ­öþfæë ´½Ô1\íÃÈCÛóU`¨ÕS·ô¦¥]Ù¨ŸÃ@†oÁ½öãâ_±
 endstream
 endobj
-
-152 0 obj
-[164 0 R /XYZ 72 712 0]
-endobj
-
-153 0 obj
-[164 0 R /XYZ 72 570.336 0]
-endobj
-
 154 0 obj
-[164 0 R /XYZ 72 225.276 0]
+<</Creator(Typst 0.15.0)/ModDate(D:20260908191936Z)/CreationDate(D:20260908191936Z)>>
 endobj
-
 155 0 obj
-[166 0 R /XYZ 72 280.224 0]
+<</Length 996/Type/Metadata/Subtype/XML>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><xmp:CreatorTool>Typst 0.15.0</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-09-08T19:19:36+00:00</xmp:ModifyDate><xmp:CreateDate>2026-09-08T19:19:36+00:00</xmp:CreateDate><xmpTPg:NPages>3</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>j3J8RuIigvUPeb1jlm2Xjw==</xmpMM:InstanceID><xmpMM:DocumentID>j3J8RuIigvUPeb1jlm2Xjw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
 endobj
-
 156 0 obj
-[169 0 R /XYZ 72 712 0]
+<</Type/Catalog/Pages 1 0 R/Metadata 155 0 R/Lang(en)/StructTreeRoot 13 0 R/MarkInfo<</Marked true/Suspects false>>/ViewerPreferences<</Direction/L2R>>/Outlines 12 0 R>>
 endobj
-
-157 0 obj
-[166 0 R /XYZ 72 370.336 0]
-endobj
-
-158 0 obj
-[169 0 R /XYZ 72 448.51 0]
-endobj
-
-159 0 obj
-[172 0 R /XYZ 72 712 0]
-endobj
-
-160 0 obj
-[172 0 R /XYZ 72 550.56 0]
-endobj
-
-161 0 obj
-[162 0 R /XYZ 72 568.1335 0]
-endobj
-
-162 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 150 0 R
-    >>
-    /Font <<
-      /f0 132 0 R
-      /f1 138 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 0
-  /Parent 1 0 R
-  /Contents 163 0 R
->>
-endobj
-
-163 0 obj
-<<
-  /Length 1512
-  /Filter /FlateDecode
->>
-stream
-xœµXMo$·½óWÔÑ>¸T¬"	¼²ƒ$È6$ Ûm[²vå	‚üû ØšnÍX‹${Îk’U¬W¯Š=sñíÓáýÝÍp€7o/ÓÇÄ@@ðU¥	éb ~O„-7âæ@ØÌ«K±øê¹5ø}Ø§Øùœv}»4šÚ¥ût—~Lß¿½L‹×¯¿N ß7Ãýí¯ðÓÅõã‡_âÑÕ?ßþýá.þ|{óëíS<ºîø‡›ßÞïoï÷é›oàÍw—£Å«7ûÉÚÛË¿|4Ï~LEÀ[†‡$6~Ûß8#«ìúŠgtŸþ‘öéc"s®Åm$åO&éai™¹ ä‘)îüSÙ:A™I@¨bƒ‡¤MQu‚Z·Š¹.ÈIaH3E«0md´“Õ	)KC©Ë¬fŒ¥Ž-ÀhF=Vº Íp—²V&B6ÈFÈ°äÙÇ†¤E1ç	ª3
-09ŸÁrî…ú&QÂ¢³Å	)Üéó¬3fÆ"]Q¸1RP+ò‚w)«EXBkƒ¬„Þ&Z»›™ã!Ý'³‚\Éá!™5lÀ­an°ëP f…&XB¹4ä¶…"›ÆjR¬ú³úˆ¹'J$¶Øõ…Û¾?Dj•ƒ‹-÷‘®1’Ý'ÏÝKF²(ÄRbß„w3–‚4/$
-,àîV,n†^g4$×.“yV2¶ ¬ç3Š|Y¬°h®Œ¹+±TpÓH×„†ä…°É2[-Ö:–qÖ’•BC*$è<ã]*ÄÐZDîµ…ÌCŠn‚uCrfl6A‹õ“NË‚Bò¡è	çUÔŽbÌàæQPŠƒk$xž­¹WjÔdTB¸Ñ¦ƒ› „z’ÊKIÓ(-ª±Z”âCâÚâ€.v‰kÁVº¬ª¡g àªa‹`HœæÒÛ/gÃÞ¸8+ÖhÕ8Kg”õ$#50Ií7´Vzp4p‰2±àÏËXÌÔ%Ò#_…V©æ\GÖÔ5Ä‡.L•+HX´Z*X¨FD‚Ø!1GS¥†ZÃ1KD£ñ˜ÙâtÊ)c.½Ý(Âk½áŒx—Øíyµ)jéHõþv-*_Š…-±&vIJÃ€]|R¥·Œ\CR„2HÎÈ‘oi51)æ¸Ç¤54æ]1Í±öÎÈÐSÇ=w‘ûû~à
-"Ž\à!Uê;ÈÃN•QŽ9@,d‡š£ù‰ÇÉ¦qv!
-Q÷’òŽ¬öðjðX¸z4‘Ø¨A~	C+÷C¿}<}[òóm¹¼ÓŠV›­/ºš•µ(
-i¶¸ó$ž‰Ý›ëDpý”.î¤ÂõÝñ{ÁõCúé‹Ÿ‰èg"žF™FÆ<6¾Áe³n´ó®Ž>÷ã<vïúçÓôÌ×6x²)4¼Z=Ld5K”¿ü®ÿš¾¿>G®œ&77CÉöÉ]:&‡D×Lá^CãÛßnö¿Á·û/ÏÄd«oã%õ¶å%ÂËñíèµè8 –?
-HòQIl‘9â/r}·ÉÝDŒÒfg>"j¿ÍóÊújÍ¤§ÕŽOô©|Z_Ë¼ü7ª\¼ë~±¥´Mö¹Ÿ‘S)èG9½¼z]§W—O
-ÿJÞN?$z[¿™®Î	,ŸÖ”–†Úþ—:‰‡ÿk’3MÈWÏß½Ò†kos*'+ûMsÒOŸ6çXïÜFá«=yãÝ×=c‘ûZv/8X„w|¾3‘Måuäãµžcg$a[áÏ'‰w›ƒú¦ãø„y8Ó7hcknÎ³9!”ç$ÚÊÚÆóZçé^ãÍüF6rÒãÅ9fÖ»ž^+œ×àg ñk¡|Æž°M×:=ñeMùB­}Bõ.WÁ|,xnÓ›
-Ö¼’È¶RW¢œÏ¯vôt#kÝ¼ ­ûÇÆþÊÂ÷fœÅ|ZR[›ž2ÛöOG9#Žø!ú9/?•Î3uõ¬ö­(>©UÏÞÕ/þ<{óx8<>¬ÿ?ûÓããáÕÿÏþ,8_X
-endstream
-endobj
-
-164 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 150 0 R
-    >>
-    /Font <<
-      /f0 132 0 R
-      /f1 138 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 1
-  /Parent 1 0 R
-  /Contents 165 0 R
->>
-endobj
-
-165 0 obj
-<<
-  /Length 2368
-  /Filter /FlateDecode
->>
-stream
-xœÕ[Ýoä¶×_1I.i.‰Ç~³½s¤.ha}ÈåÁÞœ{WØë‹³EÑÿ¾ $jÅ)íº–‘¾¬D®DÎÇÃÎèôëûÝûëËÍ^½>k~m8‰$ln›Ó€ÍoÀ ƒ `A`0Ö[éL¼µÚ	à·Í¶‰oÞ6–$¸i¯qˆ›¦ê¦y×\7k¾}}Öœ³¾xÑ œ~½Û]nÞ½ý~:½¸ûðsì:ÿ×Õî?ÞÂé÷o/y{».Úö_/ÿñ~{¹{·m^¾„WßDª´h¼Rà´‚ÛÆhÑÞÝtw2Ä»á‘¶ù®ù{³m~m
-­½#‹œ;²aÇ¢ 4‘s :©P+‹(mZaÈ@h‚oÐÜ6äzåA¢²pÓwœ^yƒVy@^¡”ñnÓv¨m¼¿iH´º}B+ôñ5–HÁ!YØ4R£ðŒAy§€&6]$€,êàÁJ$ ƒA{°…‚MAð E@"¸iNê ½Ö^‚$Ê*kÐRžÈ8®ñÎƒA'<H)1P¤—"2<(PùH IôÒƒŠ¤ø?:Dš‘ß€N7Š3/…ÊvM›u£›Ùw¦PNÃM#]@Y3c¿—h½©=:2Š:Ò¯5’ŽïÎy ¡PG¼ÊÐ‡`ÑIÁ¢-Q»VtÚ•°iÞuÔÇÉ¤ErpÛxŽ¢\mÍË¶EBÇV|8ŠÂkÔ>²ÞÿTdE
-Þz ©0Ø¶ùŠû(èØ¡„ò)@|YEþÈÅÑ!›vÑõËîüÃå¶_r¯Ïþòˆý¾“`½G¡sÄ{­H9¥PA’‰à—±Ošñ¯.÷Íéµ )àâzlL\Ü6?}þFñF(Ý_M{½j·íï}÷èŸÔ?i'O
-åâúew•b4Ìuß×M#¤dƒ«¬¿\ÈvØ7BÍ(2²†¥ÎF¢¹»ñ“åÜ%â;‚>~þ3\üÐ|{11–ÌD·š#M7½‹ªÒÑ²8a¼—ím¼QFÃùÙ@ÿn4¼î-v22ç5˜P&Æ µÿNHÎâ¤Wõb&7"dR"é"é-]Õ^â»\ñ”  KãÌ:-C“rÇhkü„šN„f³ïAÖ?¿-ÒºÍ‰LÄ¥1†þâ[Ã08'
-’\‘åÊÜeúÙ[¬wO_“²‚IeÐ{¿&w™.˜A‘\³–I?78ËZKãç¦¨‚âLÎE Ž(b×	&U6sB™*Ï\áã¾2v’–,p³›•èŽ!‹K`N"û…\¤öY™Ø~‹JCnÇöï#â`ðª
-xÉ"‘\Ï ÊLŒo¹b®Ûî¦êÜ¸¤Ù8Ä8ˆ¦²/%]9P`g÷°™Ô”šlJ¶=µ<%{v~Õµ—º?¢ºQ,*e×‚è§™öda¶atì}–I„Ù°ä=°Ý-ƒßúG:Üv«åù;_ì»¾Ü·ÓXÛâN]ÞîËZUjI#¦¢mQ9»–·þIŽòÉªHp¶¬ÍáWtu'bâ«÷bbaAr•†·(óÎ‡êOÚ(?ãZ®´­(1F ë,©c-RÚÜìâÆ—‡9ý_Íí¹aK½*ESÄÚ²°AO¬a¾ªï³†ÇùÅåMeâå•7•	¥9-'ñKê4›t¼ënËîz}¢%ÓâÊ¨ÔA£”«!ódv—ã>pËdîø-"Eƒ¿­[ØuÅy¤ú˜ª¾7Žˆ}»§¿bAYaÖ ØC•{x5Ü¬è.!ÒWé4êxd¶š‡ü;	JøÚÎ qUtÝq#² žûµÌ™âÀ=p–ùp™‡Áif~Ë’ëÎucš‡„¦»CQ*(5­“O†R3ïê%B9„¹˜X¸µ­„OÜdoW¬XnŒ˜IHŠ«žEQ6GZé©RÄTÖ¹W^ny9qyÈàF@=ð$b<T=Ý6•¢¼@¢GpvÑäîîÂ´F¢VþÉ§­’O=­tƒQáÉù•†P>F(sÄ´´pèÂ±¹ˆñ|a!QÌVYÐ”Mü ˜¨nmŸÍ¦K[•’'ätTÔÊ”ZH`	)).­+mQ®Nñg™kô_çÐ"/Å“V*dðA;4sËâ¶ÁzYÒu@­ÌV
-Í¿œ†©<SàÙ0u”­ÏÆlbñ”yTô@x~krÆ¼¤ÇÔ}ñøÈ‚²ÙÆúDpÞË1‰ ù(ûSÁEŽÜš×å*¡9SS~ØŸ|Gv8)–íŽŸA÷êlµZiiåN´ztýC JéXdó´€l{ºªÅô±˜ÁÝª´ûÜZi¤‚8†åÁÏ¾ßŽ‰j‰³þõóEAÍø/Š2Çú±%5RçLÝÇ`Žg‹ºW«²_”ÂŒOôPEƒ,q_Voùd5¯Ã(š„cVPÅµ’>†=ú‰—þ‘µ5õ”Ã"Û3î×Ê¬§ŒHˆ?dñ¢›Lé[°ÈåŒw¶>—Ç”}e	ÂÌZæ¾«ò›wÖÄ4«ûl,Çô0ËQä'?'¥#$ZÜQeÅÇ“6‹êŸh]ý)þ¼ÈÙåð<Íxy+ó•ÖöÊëeÆß[™Á?3ZË)µ‚R+§ßR*Šµï«÷ÇØW#V³cÖž™ë,%\K¹‰Ì ðr^a—‹t–¦çã¢^Tg¨C  ré­U‰ *Åßd=†5‹zËGßµãyËbÕÕÂ¨»,˜cÎ_î5WS³ùXØ4l5åš«Ôµ Ô²/+¥¶y4+á88‘R2<“˜—?ð2‡ü˜®Vž6Iç/ÖHVªÎÛo'Ö«:?¬Ì„%¯XËAE(õºœ‡Ô¦<°´f¹êLU
-­IRü¼HÐªuK#x±e:_™<I‰ÒL…àAõÁ…Œ!3I‹˜•÷³E»Pi]ŒáØR[ÀÑž{óˆp\«Djž•Rj„žäzðÜË¯\01É_ó½¢¬ár¹ù}í7‡ìeƒt_ÄEK•:†ùrº%2páC"ö9×bõuÕõ›|ùúên·»»Í?~ýîîn·ôñkVG*PÇÐ÷1?	cËc ?­+ë´‰‘Æ»4ÕøcØñ¢
-‹&ÿÿç‹®7­ÛÏLç#•dg”F»’ø†H÷9\üs ÛŸ™ëD
-endstream
-endobj
-
-166 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 150 0 R
-    >>
-    /Font <<
-      /f0 138 0 R
-      /f1 132 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 2
-  /Parent 1 0 R
-  /Contents 167 0 R
->>
-endobj
-
-167 0 obj
-<<
-  /Length 2233
-  /Filter /FlateDecode
->>
-stream
-xœÕ[Ýo·ß¿bÚˆÊ#ÎðuÓZr‚¶¨‹: q¤‹»8œËEÿû€ûA-yäîIº³á—Ûår—œþæ“¼ÓW›íû›ËåÎÞœ7?7¼ë–·ÍéRÀò—F W^7 Ðkã[n²B{øe¹nÂ—·!«ö†X5ÝP«æ]sÓü»ùöÍysg}ù²8}µÝ^.ß]ÿßŸ.î>ü]üzµýÿ‡k8ýëõå×›ðhÑ¶ÿuùÓûõåöýÝºùæ8{¨ÖlP;)Á*	·V¢½[uwìÃ]|¥m¾kþÓ¬›ŸB)gÉÆçãÉ°cQ{Ed-¤N*ÔÊ"HEéVì	µwà4:‚Û†œG'0J«†œEotÈi4Ò r™ÃÝ²!eQ™p¿jHi4ª}CItáb$ï€,V(œ­ÑÞÉ£M ƒÊ;0Œ¤Ñ+Æ¢°"ðXx$‚UóB òì”rL
-¥‘Æ ¡!/yà0®vÖF+03z
-ôR@†)<J FÇdè  ÒH¡Ÿ­"‹ÚÆfà×£•ñÁª!Ma¦ø–(M×”¡©QP7ºö}«ÛY+´
-V[6°¦ÃsÇhœV­¢ô+…¤Â÷Þ¡µHHT¯ì=jràZö]h	$«kD·ºËæ]G}˜Œ’…ÛÆ	´äjÂhŽÛ	Záå 
-§P¹Àzßíe`……@gKô¦m¾Ã.:<Â9ƒä!|,dÃh!ËVézµ»øp¹îUîÍùß^ƒ¸W¡¨ø–Áx‰†U
-y§$I+A é™t@?‡g¬;ÈŸ-‹Msz#€7ck"`qÛ|ÿì­âíUû+ÈvWaº+ëþÚµ·}¯ìß–ã§L}¯êÛ"Ë¦WÁíuŒÇz<Ú—å—È¤SôCÞ¢ÊïG6UFºI„!S!dlGc¿JFÙ$O×ÉÌWÝEfO×É—j<G¤HUøÓéól9mqÖ8Æó`ñ÷æÛE²T¬íÌâ± ›ƒsæ:[•¡×f²0™ì2ÈK9Ç7‡»\®‚g×ëç!(ƒlùñB I!üa 5Ad‹Š“LÛ:(Ü”™–‰èä *NÛ¹fG‘Ñš;zž}ÕÏ¯]ÿ‹1yqe9‚Ëý=;›ñÄ8·|²²bäÐx“¬˜±JîÂâ©p7Š,æ1Û®–‹ÿNP¤
-9eš¨J¶bE÷²’ñ«Ôú­“§™‹È]E´Ki{]¶æ<m¯ì”sŠÚQØØ{€tro‹<8*;VA]ñ^vš¦ì»«ÑœÛ’Ó®}?p•žçæŸS]ªö³å&›,Rf";	<"ÓÓ Ø”E×ËEÿR|š¯A4ƒÑ¼RæÒï~µJÝßùýøñðfê,{LY›‹¬LÈþáçeQý¢*‘™•)Ûcmz¥>…=¶U˜h:hh#c:“èå{30–Mñ®9ÈÃÛÌûOöšé¾GŸ~Š©hJÂæå•@vZãP8Ï‚f‘_ü.}s;‡{WÁ½nËŸ÷¾ŠûMÄ}–eÞv0%¿¿+ŠÉÈ£’1Vr¹õæw7åˆ¶o:O¶“loËQtŸ¾Œ±™¦˜;/ÅrMë¿ÚgÙ[{gSÅJy#”õ|8|$°UÑ^ ê€hÿÓ”,­ÖÓèõ(1÷£Š9-òV„i%Ô›®çÔô3â—•y©«ç9ÑàÞRõ‰µ†y…à*ú„EEäcÅ•´/Š|–ôJ­B÷“ÄkTM 4P–žô
-sqö´‡)–¾‚JhìßÎlI×û—LÝ+)b5Ý3ÚzŒ¡Ê‹—y†‘Óø1MÖ¬ŽèŠŽhÆŸLóEÖµeXÉÊÛ]û¤œè×Øâ¤V˜‡j1YÖ3Ñežd§5±4˜ê3‰O}•‘—iÞN0œJh]Þ@Ø£X_I³•ÔèÜ«õ¬°Uv0¹§þv¨ªLì”ìxú\tµ*\ß¿ô²`¡úi±št’uæ{@µ*ž)èElÝ×ò²c:&)ûV¶ÅTI”2ëð€Í#[Á#$:^)1Ý¥ÛT\LYû·‡ó¤]¶‡Då½«iEžxæ»„bZ·»vˆ´s§Ð3Ì±ÏÞÃD¶0ÎJmFzƒR16hÌ3¿YI¾ÂŠ2(íX!`Qgå4±(25Nƒ½LÕKŒ
-››²uëC’Ê~?¥õ·~ˆlË0F›©í7 åNöS;”D(ÝX„ç@óg…vŽÛÛp#µ‚‹ó65ü¯Qð¦?¤5œ+º¨n7Wj'ašÏª½ScKõ³b)2›\Jæ§ýîYÚYJE*9ÜL8½üîQöK‹?ýP'O
-¦óyÆ2¿*ïDîF[³g*‡=Ø+äãeØŸMB³9dqÚôI“}BÂ'ks‡©Ê9X^Œ×Y0Q¬"ucŸÏ¢Š+¨2„¤…xÚù9éiU¢ y‘4Qñ/ûÇ6s[qB&9ý"JéÄ½ÚÞþ«;Èéz¯îýx'†:uc3k‹’Â©Ü=1ûö€ïÇœV£¹?¶ç¬ãùüLP,ÊšöHðhâGéM¦S»`*œù®mvhkÖ8”ªºR8TÇæŠ‹ú¸wœ‹Å?ä3e{”·œ û³cž×ö5ûåHèøzvL<G_†×áç«Ô–ÇM€xå X 1@&³œ‡&ÿ3Ù¹(§²™ðÕ£Š-z?¤¹:ÒŽ½T-Òä“‘æg4 ™øÍC›Ü/Fc“›ßÙ½bŽ~=ŽËÃÛgq9¾NuãþZÏvþ}uv·ÝÞÝ¦Àúîîn;÷¬äx…@ü™:`"zráÏKÜöõ³É_íèNŒ}et{µ:³®ÞIð¿/­)Ê¼ðØ€Œd§¥Bs$ñuH6Íý¶ü
-endstream
-endobj
-
-168 0 obj
-<<
-  /Type /Annot
-  /Subtype /Link
-  /Rect [331.2 488.586 450 508.362]
-  /Border [0 0 0]
-  /A <<
-    /Type /Action
-    /S /URI
-    /URI (https://cloudnativegeo.org)
-  >>
-  /F 4
-  /StructParent 3
-  /Contents (https://cloudnativegeo.org)
->>
-endobj
-
-169 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 150 0 R
-    >>
-    /Font <<
-      /f0 132 0 R
-      /f1 138 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 4
-  /Tabs /S
-  /Parent 1 0 R
-  /Contents 170 0 R
-  /Annots [168 0 R]
->>
-endobj
-
-170 0 obj
-<<
-  /Length 2472
-  /Filter /FlateDecode
->>
-stream
-xœÝ[ÝoÜÆç_1NŒ&NíÑÎì7êˆämQ-$ Q¤‹»NŽrEÑÿ¾XIqçv<K”‹¾\~ìÎÎüæs—GßÝm>\]¬6püö¤ù¥!P àU:ùÈ°ºiŽV
-V¿6
-£‰Š¢…ÑºàØÛtéŒW6Â¯«u“¾¼i1(¸nÏ©‹ëfÛÕuó¾¹jþÞ|ÿö¤9F}ýº8ún³¹X½÷üptvûñÇtëô_—›ÿ||G|wñÓ»»të¬mÿíâçë‹Í‡Ûuóí·pü&QmÙ¡Zƒ7nkT{u½½â˜®†WÚæûæÍºù¥Q¨Œ	ž|šXšùøFÖí˜ÄÑy
-iËjy‘¸blËŽ„6ÁMC!bÐµƒë†‚Çè((Xt:€
-™ÓÕª!ãÑ¸t}Ý±èLû†ÑÒ ÃH1 !9X5lP… Ö¢Os§ˆ65}"€šÀ1Åh8JÃ*± `‘®›W
-Mä`L``2¨vE(§~mð,z€™1R¢—2hQ‡D 1 Ó"‹”ž¡·@äÑú¡™æÑëáÆuC–ÒHÃV£vÛ¦NM‹Š¶½Û˜¦ïmÛ![ƒÞÀuÃ>¢OS³Œé~`t! ›€Þ'V'úA2éûÐû ¤4š„WŽ-ˆ=G‡!µ$é:µ•.Ãªy¿¥>ÆÉÃMzJ|u©·Àm‹”I­ôrbE0hBšz÷8ê4V
-ƒ@¬1º¶™æ•&£Ó­PpHÒÇ:Í|êM²j•®S»ÓëNåÞžüé¨{ß3¸ÈÙåF“ö²Ò‘É&ôsºÇvùã³FÁÙ]st¥€4œ]­‰‚³›æ‡¯Ï•RçŠM{¾ìZ´=+“·™·gÒãvzQ_‰G:ïBõ]v]¨òó-›Ñqt ÂÇãíèJ»q9½]GÚV:ô/~„³?7ßŸíCa‚}{G½ïeqrÚ(>	Ã$ãá•ÛËt¡­Ó“¿6
--ü»1ð¶3ÊÆ´­%97ªÕ½x²a¡IÚø„ÃZpÆ IŠxÐ¨ãñb>šÔ3*é™g³q?IÏhŸž`®4u/×­¡}'1*gÄ…iÐ,=).*âºŸÅÝº"	+Ùá4Ó^š!ž¥Ãc³ÑÞ>Wª³%ìó3ugåó)w"Ú”ŒçïóO·]½¬ô×(r
-™m;1m=fv'ŠŒŽo¦øoê¸YToÒá«Üxk’ç)êm=6fÆò±i?WZ	Jû6€§N^ë\Úƒg´E¹É1Ó½½.#ª€˜{·—áô«|°¯y»ZL;b®
-±…åÔbì·Å˜OW¹Xÿ_¿[¿¨ Îgnò±mì—#q'ííýaŠþNËNá¼=¶pú&W‹ûóÔLb9:¶Z·™ÜCPÄÿ§Î¢¿¿Î©ÆemˆÞ»^6"P•¹»¼÷&¿ÇŠHƒ&ÌÞö*MöeÅpº’|YÎ{²”)hR%s³dP9~bl~YáD/íÜ=Lz³<¹°«²v†våcÊ³öy'kçlÈçã.r°¬KÐ+‚~dÑ’µnÄww7Ó0¦ár‹wÆžDa1¯a0Ñ ·
-ïß‰kSZÎ, IôŽs¦<dº*©,•€R´º÷tÌíÛå¾0­8ŽœÃz¶ ‹iœ&¬Èpºì9_†;¾!—R/Ÿ\uD¼Øç´Bîºl©/'¹SJUO€ïÜòU¼ã$ý¦¢žÞ ¥E}ÄçT´ždK1‹c0lÐÚ‡¤¬êléó‚r 0ø>¡wå*MÎ52KwòÕzèì"$ƒ!7bÌ§×ä&jdn2ñaÐ‘‘üÃ²†=Øµ™ƒð…HÖûE„8ÊöUc?nu…á¾5®/÷â–!‹*¼—•<ß” Ý]?Æ )aŽµšÔ#_Lîº‡‹iž4E¦ž!GðŸRyÙÍT¾"üÏÞ|D¨ê0¥Iî‡Š†xF—ÍN?gin"*˜žG¸’[AD]k‰ñ0hÝ•âüáË<\ÿ½Ld²fÕþà¬ R7Ñ–Ññb¹én’$3Ä\ÿdY®`Hv°“_=†b”3ß+t@µtÿ¼z™ŠE”Ò]‰-ƒl[Ö¥ü»gcŠŸŸÈ\­‡íg&W¦*¥­ƒY,hWwÝ0?Y5ê4/Oçß¥Ãkp-°<d<“\¢9Ñ–²È~©`«€È¬MjXßîýgV
-VÝU¶ÝýÔY`¶³ß@P8q)Ÿf)$z /çED¿Û‰ŠQ!y·†wh(4€sä_ŸÏŠŽÄJóè¸ãì÷“ Þº<¤3)ÉâB1‹&.Ùn*…r}ˆë¦~··†(@²¥ìZjQÙ¬Z¦,þ÷³Ž«<r¯öc›mjtåÆä&ˆÃJ‡M;ÆÔ’áTÒdkÿ;¥K]ª„K(¹ƒbª¾rÿ•ÖYJÑþ=òjõdn¨7Q¸ì‘zH³£RÈ–:Üž>+EçÇP'[©²±I»OyAàf1˜„æñþl§\HßA€­,<d%gmsJdLµsikï’E²,Å+wí³W£×ªu²O+{ö˜í¬z_I›¦•*Wi¯ó£pofq_i³c›ÂúÞðN^¯–ÜA˜+Õ"]Ô³"Œ’ÇïÒcÌ¥rR¦•zÅ€6ªE*Å’G{©©r–Þ¿¿¢\¬‘îoŸÐrF_V¶+ä%%]¯³æ¾{ÂÍÉÊŒtlùê®ž0Æ9€%‡D]aŠïåÀ1ŒÊJ-Œ|À@fITv3+†âµjødè“‡<r±D£p‹å¼p0µ`§üU1œ‹»Ã*hÓŽY«Ž9ýÎÂ:ýšñ«Wƒ7Ì¶{çþ56u%çb÷Ÿ‰Rí»¼’•­ž½’TÅe7Êð;¶`b3Îü*.m[ÑlCBóœÿgO@gylQfìS->Ä¯M›HÍuÑ„Æ¥ßÛ–Ëp%ÒksÄ
-‹ÀÝ¬íES¦uÙ^R¦}OÒ Ò¡eé*å÷ï‰ÞzØN¾*œËÎ^!¸‘Å›Ê1Ì$f+ÕA"Bl\néûÕÛÙ›$ŸºVxèf½½Úô¼óIOQß³ó[òñífs{“ÿ™ü‡ÛÛÍÔŸÉÙæ\…&-º™GÜJ#ð0RQ¥óÆ¦?|ÓU?TmË^œ\ùŸWõzvxÑëqóá5¯ö?¡0ã¿GF¼³Ú [ˆ}-÷ô8ûç€´ÿó9b 
-endstream
-endobj
-
-171 0 obj
-<<
-  /Type /Annot
-  /Subtype /Link
-  /Rect [270 441.172 450 460.948]
-  /Border [0 0 0]
-  /A <<
-    /Type /Action
-    /S /URI
-    /URI (mailto:michelle\\@cloudnativegeo.org)
-  >>
-  /F 4
-  /StructParent 5
-  /Contents (Email michelle\\@cloudnativegeo.org)
->>
-endobj
-
-172 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 150 0 R
-    >>
-    /Font <<
-      /f0 132 0 R
-      /f1 138 0 R
-      /f2 144 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 6
-  /Tabs /S
-  /Parent 1 0 R
-  /Contents 173 0 R
-  /Annots [171 0 R]
->>
-endobj
-
-173 0 obj
-<<
-  /Length 1860
-  /Filter /FlateDecode
->>
-stream
-xœÝZÝÛÆß¿bœ¤MìÚs;û½@ ¾8h‹ºhqúçá¬œb:£¨(úßCr÷¸#ò¨ëU}èƒ¸äwf~óµÔÅ·ûÃÇÍõú ¯ß^ª_¯¸‰ÙÀúV]¬5¬U³Ëšr Ù‡LôÜ.jŸá×õNñÊ[È€†m×2‰­êImÕµQUoÞ^ª‹úÖ¯¿V ß×ë7?Á«»O?òÔÕ?Þþõé.~sýÓÍž§VÝø/×?Ü]>ÞíÔ7ßÀëïx×ÞôÉZˆÎÂ­òNw½mß3™{õ‘nøAýMíÔ/J£v.EŠÌs>žhÈŽEA&;¢A#õR¡N,ç;a˜Lès‚ä1Ü*J“M`ÐØ*JsL 1Y ä1Ø(Y4†{kE.¢Üß*rƒëžp÷Ð9ƒ”R€µ2uJà=Fæ2zFÞ t9A0H@³K"jkAN`tF"ØªW]6É¹dÀCl@(ëDÓõ)&ðucfâý##ÕmâÁdX¾A@ä‘ø>FD}¬Cæ7c´ub«È¿©.ðmè‡–‡5õÔ}fö£ïï0:Ø*3FfÍäùd0¤Æ%Œ‹š÷ï’ãõ9aŒ	H[tŒW“3zJF&L<ÒHÀÚº×®µúÐïž_fR„[•4Fb¹¦–L7"íxÄ³(’C—˜õáv¶ÌŠÑSH@ÆbÝùb†š'¬N@) eàÅ–ù£ÈÔÄFÖÑfwõéz7˜ÜÛË?|úÞ„ªáG!%Ô®E|r–l´ Ñh›y¿á9ã{Ä¿^)«½ºØh0V›±3Ñ°ºU?|õNký_Þiã‡Öô-Ù®Ýó†[±o­i5¡k7|}uß­7´v“Þ7o*w‡YCbS®[ˆÏ„ÕÕ›Õ‘+´“£ÉñòJiL‘éØî£ö)™®Ëë\]þYiôðOåàíàO‹¸šS"Í(Ñ{á	Z$ 3¯ÅwÚBÖc1ºë®ôftGkÛ*A‡ñŠŠª@jžª­õ•ÝX‘ÃÚ½Xå»Ø¶Be|´Î	5;y)n’`¶´-›B4bÖ5;ˆm	qžãŸiv W9Át;Þµ´­´*/Þ1¼“ÚçR¥Òr$Í­Ç”Òù€\÷ÄŽí"È„ŽŠ|«\õ4¸6‚JmºÅs†MH¬~€‹a¬áDŸ¶s±ÃÃ´4æp%õ!°\M·®Ó“{±Sï6vOûd”Ú”R@"s6”FÊ‚‘LfÖFx0éùªºFyÂÑ<	”Rå•º4Å|z—4<ãËgãéÏgÖÔ€Þòa¾,‰±9É8›ø'Ü|Y³³Å¤däY„¢›†¢Ï­çs˜mÌk]JyEÃ/¡ðÈùV§,1¤g÷z+nN¢¸ìuJOG{RSûéŒ ¾A £‘Š†"“}œ[•2á~$¨²­è»%ñ/ÍÏ€-ôgÄÚ•¦ÓžÝ´f–¼ŠµKÌ†fMÀp®ºhä™Í„ŸØŽ=âûÆ×Îrù@©â)Ýsv®J%NKÕe‡Æœ³R)ø'$"ÎULÅ3ØÜù ~Z´ìŽ24á¶jÐ—UG™Ÿ®sDu^i'œfxÉ¦Óú¢CÇ§0çAßË)DÔ0 ‚¥”÷œÞš|½FFY+ÏÄ¶ÿ¿ìð¦..—À“¹÷§ëÝÏðÕÍîù’\ÀŸPè‘DS']%*ˆ*¢(m›œ„q¦VÏPÂó4uNHžcá“y^ôÝnæêí£DiÒ¾f
-†7§:š:y3QOeù“Á#ð¶¦?:©ò )?ó}»èÈo´9êî¡Ó;áCÊ«ˆ·vZïlN°:²ÉÄœÿsšÓrÐÙz»tÁßÂ‰è~¦îÔ@-•kfinfòIÉ5œ¬ÈÊê¶ê»ÇŒ/25ù«H=š³áv×CR"ªå!5)n°Msd%Vð×žlMÉhAËÙS°JüEËœ©ÿK©.è·´"F×À%Ræ~^|ø©ÄHøqqXÜPÿÙ”¶åm¿ä³	Ñ?ŸG‡Ü†´”^š_ŒÍå7ã'Ûˆd7b¼Ÿú²]¯ZÅWªS¢•; ™0Æp6|>oÕv¤N¡æ¢Ö:_ÊÉäfTçµt÷"Vu«_Œ\Þ‚zÐ‹ƒì ñ»ñ­“|ÿôËÙˆzh2³x¼­B[|AhÁ^M>´lÌœœÍ°]>LXSa¾ýŽêNF¤?‘OÉ-Ðx¤˜Ö•÷)ç@úÀqËÑŸ\^ßw·íÿ\¾¿»;,ýÏ¥9±Ñè´Ö÷ç&ÿ…S­fJü‘‘Btžÿ/Â½òª¹$6ÏNÊ=‡LåÙ#RPÝëpÈèe&:ýaJ,bköï%Ã‹‘ÊG²óÖa8“ø:é}ùV¯Hû7µý”
-endstream
-endobj
-
-174 0 obj
-<<
-  /Creator (Typst 0.14.2)
-  /ModDate (D:20260507172023Z)
-  /CreationDate (D:20260507172023Z)
->>
-endobj
-
-175 0 obj
-<<
-  /Length 996
-  /Type /Metadata
-  /Subtype /XML
->>
-stream
-<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-05-07T17:20:23+00:00</xmp:ModifyDate><xmp:CreateDate>2026-05-07T17:20:23+00:00</xmp:CreateDate><xmpTPg:NPages>5</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>H5VTyx0aDkyBwgNDkZ2vsg==</xmpMM:InstanceID><xmpMM:DocumentID>H5VTyx0aDkyBwgNDkZ2vsg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
-endstream
-endobj
-
-176 0 obj
-<<
-  /Type /Catalog
-  /Pages 1 0 R
-  /Metadata 175 0 R
-  /Lang (en)
-  /StructTreeRoot 13 0 R
-  /MarkInfo <<
-    /Marked true
-    /Suspects false
-  >>
-  /ViewerPreferences <<
-    /Direction /L2R
-  >>
-  /Outlines 2 0 R
->>
-endobj
-
 xref
-0 177
+0 157
 0000000000 65535 f
 0000000016 00000 n
-0000000114 00000 n
-0000000194 00000 n
-0000000336 00000 n
-0000000457 00000 n
-0000000576 00000 n
-0000000778 00000 n
-0000000940 00000 n
-0000001050 00000 n
-0000001165 00000 n
-0000001281 00000 n
-0000001405 00000 n
-0000001499 00000 n
-0000001782 00000 n
-0000001865 00000 n
-0000002151 00000 n
-0000002387 00000 n
-0000002644 00000 n
-0000002775 00000 n
-0000003098 00000 n
-0000003175 00000 n
-0000003269 00000 n
-0000003346 00000 n
-0000003434 00000 n
-0000003535 00000 n
-0000003682 00000 n
-0000003773 00000 n
-0000003861 00000 n
-0000003968 00000 n
-0000004062 00000 n
-0000004184 00000 n
-0000004284 00000 n
-0000004376 00000 n
+0000000085 00000 n
+0000000192 00000 n
+0000000282 00000 n
+0000000377 00000 n
+0000000482 00000 n
+0000000592 00000 n
+0000000707 00000 n
+0000000841 00000 n
+0000000939 00000 n
+0000001018 00000 n
+0000001142 00000 n
+0000001210 00000 n
+0000001414 00000 n
+0000001565 00000 n
+0000001891 00000 n
+0000002116 00000 n
+0000002220 00000 n
+0000002282 00000 n
+0000002338 00000 n
+0000002408 00000 n
+0000002515 00000 n
+0000002586 00000 n
+0000002657 00000 n
+0000002757 00000 n
+0000002825 00000 n
+0000002938 00000 n
+0000003009 00000 n
+0000003094 00000 n
+0000003173 00000 n
+0000003247 00000 n
+0000003318 00000 n
+0000003415 00000 n
+0000003517 00000 n
+0000003584 00000 n
+0000003645 00000 n
+0000003714 00000 n
+0000003782 00000 n
+0000003854 00000 n
+0000003922 00000 n
+0000003990 00000 n
+0000004060 00000 n
+0000004128 00000 n
+0000004197 00000 n
+0000004268 00000 n
+0000004336 00000 n
+0000004405 00000 n
 0000004476 00000 n
-0000004568 00000 n
-0000004671 00000 n
-0000004763 00000 n
-0000004866 00000 n
-0000004958 00000 n
-0000005074 00000 n
-0000005179 00000 n
-0000005326 00000 n
-0000005428 00000 n
-0000005513 00000 n
-0000005787 00000 n
-0000005878 00000 n
-0000006152 00000 n
-0000006243 00000 n
-0000006328 00000 n
-0000006460 00000 n
-0000006592 00000 n
-0000006677 00000 n
-0000006809 00000 n
-0000006941 00000 n
-0000007026 00000 n
-0000007158 00000 n
-0000007290 00000 n
-0000007420 00000 n
-0000007522 00000 n
-0000007607 00000 n
-0000007881 00000 n
-0000007973 00000 n
-0000008247 00000 n
-0000008339 00000 n
-0000008424 00000 n
-0000008557 00000 n
-0000008690 00000 n
-0000008775 00000 n
-0000008908 00000 n
-0000009041 00000 n
-0000009126 00000 n
-0000009259 00000 n
-0000009392 00000 n
-0000009518 00000 n
-0000009608 00000 n
-0000009730 00000 n
-0000009826 00000 n
-0000009986 00000 n
-0000010071 00000 n
-0000010162 00000 n
-0000010251 00000 n
-0000010336 00000 n
-0000010430 00000 n
-0000010519 00000 n
-0000010604 00000 n
-0000010694 00000 n
-0000010782 00000 n
-0000010867 00000 n
-0000010957 00000 n
-0000011045 00000 n
-0000011130 00000 n
-0000011222 00000 n
-0000011310 00000 n
-0000011387 00000 n
-0000011478 00000 n
-0000011670 00000 n
-0000011760 00000 n
-0000011964 00000 n
-0000012085 00000 n
-0000012180 00000 n
-0000012465 00000 n
-0000012750 00000 n
-0000013035 00000 n
-0000013131 00000 n
-0000013266 00000 n
-0000013401 00000 n
-0000013536 00000 n
-0000013632 00000 n
-0000013767 00000 n
-0000013905 00000 n
-0000014040 00000 n
-0000014136 00000 n
-0000014271 00000 n
-0000014406 00000 n
-0000014541 00000 n
-0000014637 00000 n
-0000014772 00000 n
-0000014907 00000 n
-0000015042 00000 n
-0000015138 00000 n
-0000015273 00000 n
-0000015408 00000 n
-0000015543 00000 n
-0000015636 00000 n
-0000015757 00000 n
-0000015850 00000 n
-0000015987 00000 n
-0000016135 00000 n
-0000016214 00000 n
-0000016307 00000 n
-0000016439 00000 n
-0000016583 00000 n
-0000016755 00000 n
-0000017208 00000 n
-0000017298 00000 n
-0000017552 00000 n
-0000018996 00000 n
-0000026560 00000 n
-0000026735 00000 n
-0000027210 00000 n
-0000027301 00000 n
-0000027558 00000 n
-0000029226 00000 n
-0000038044 00000 n
-0000038218 00000 n
-0000038606 00000 n
-0000038695 00000 n
-0000038954 00000 n
-0000040272 00000 n
-0000047743 00000 n
-0000047781 00000 n
-0000048204 00000 n
-0000048246 00000 n
-0000048292 00000 n
-0000048338 00000 n
-0000048384 00000 n
-0000048426 00000 n
-0000048472 00000 n
-0000048517 00000 n
-0000048559 00000 n
-0000048604 00000 n
-0000048651 00000 n
-0000048933 00000 n
-0000050525 00000 n
-0000050807 00000 n
-0000053255 00000 n
-0000053537 00000 n
-0000055850 00000 n
-0000056107 00000 n
-0000056420 00000 n
-0000058972 00000 n
-0000059246 00000 n
-0000059577 00000 n
-0000061517 00000 n
-0000061634 00000 n
-0000062720 00000 n
+0000004544 00000 n
+0000004613 00000 n
+0000004684 00000 n
+0000004752 00000 n
+0000004821 00000 n
+0000004892 00000 n
+0000004960 00000 n
+0000005092 00000 n
+0000005194 00000 n
+0000005262 00000 n
+0000005323 00000 n
+0000005392 00000 n
+0000005463 00000 n
+0000005531 00000 n
+0000005600 00000 n
+0000005671 00000 n
+0000005739 00000 n
+0000005808 00000 n
+0000005879 00000 n
+0000005947 00000 n
+0000006016 00000 n
+0000006087 00000 n
+0000006155 00000 n
+0000006273 00000 n
+0000006380 00000 n
+0000006457 00000 n
+0000006526 00000 n
+0000006597 00000 n
+0000006665 00000 n
+0000006734 00000 n
+0000006805 00000 n
+0000006873 00000 n
+0000006942 00000 n
+0000007016 00000 n
+0000007084 00000 n
+0000007153 00000 n
+0000007224 00000 n
+0000007292 00000 n
+0000007361 00000 n
+0000007432 00000 n
+0000007500 00000 n
+0000007625 00000 n
+0000007694 00000 n
+0000007816 00000 n
+0000007885 00000 n
+0000007953 00000 n
+0000008023 00000 n
+0000008091 00000 n
+0000008159 00000 n
+0000008229 00000 n
+0000008297 00000 n
+0000008401 00000 n
+0000008494 00000 n
+0000008575 00000 n
+0000008653 00000 n
+0000008739 00000 n
+0000008808 00000 n
+0000008882 00000 n
+0000008991 00000 n
+0000009076 00000 n
+0000009146 00000 n
+0000009209 00000 n
+0000009282 00000 n
+0000009345 00000 n
+0000009638 00000 n
+0000009850 00000 n
+0000010079 00000 n
+0000010116 00000 n
+0000010163 00000 n
+0000010210 00000 n
+0000010258 00000 n
+0000010304 00000 n
+0000010350 00000 n
+0000010396 00000 n
+0000010438 00000 n
+0000010484 00000 n
+0000010530 00000 n
+0000010577 00000 n
+0000010689 00000 n
+0000010812 00000 n
+0000010935 00000 n
+0000011082 00000 n
+0000011466 00000 n
+0000011682 00000 n
+0000011832 00000 n
+0000012259 00000 n
+0000012477 00000 n
+0000012626 00000 n
+0000012958 00000 n
+0000013179 00000 n
+0000013320 00000 n
+0000013438 00000 n
+0000013579 00000 n
+0000013661 00000 n
+0000014318 00000 n
+0000021747 00000 n
+0000021829 00000 n
+0000022564 00000 n
+0000030992 00000 n
+0000031074 00000 n
+0000031715 00000 n
+0000039314 00000 n
+0000041809 00000 n
+0000044332 00000 n
+0000046992 00000 n
+0000047399 00000 n
+0000047502 00000 n
+0000048575 00000 n
 trailer
-<<
-  /Size 177
-  /Root 176 0 R
-  /Info 174 0 R
-  /ID [(H5VTyx0aDkyBwgNDkZ2vsg==) (H5VTyx0aDkyBwgNDkZ2vsg==)]
->>
+<</Size 157/Root 156 0 R/Info 154 0 R/ID[(j3J8RuIigvUPeb1jlm2Xjw==)(j3J8RuIigvUPeb1jlm2Xjw==)]>>
 startxref
-62958
+48762
 %%EOF

--- a/static/cng2026-sponsor.pdf
+++ b/static/cng2026-sponsor.pdf
@@ -2,3344 +2,1542 @@
 %€€€€
 
 1 0 obj
-<<
-  /Type /Pages
-  /Count 7
-  /Kids [246 0 R 248 0 R 250 0 R 252 0 R 254 0 R 256 0 R 259 0 R]
->>
+<</Type/Pages/Count 9/Kids[291 0 R 292 0 R 293 0 R 294 0 R 295 0 R 296 0 R 297 0 R 298 0 R 299 0 R]>>
 endobj
-
 2 0 obj
-<<
-  /Type /Outlines
-  /First 3 0 R
-  /Last 3 0 R
-  /Count 1
->>
+<</Parent 17 0 R/Next 3 0 R/Title(About Cloud-Native Geospatial Forum (CNG))/Dest 257 0 R>>
 endobj
-
 3 0 obj
-<<
-  /Parent 2 0 R
-  /First 4 0 R
-  /Last 17 0 R
-  /Count -7
-  /Title (CNG Forum 2026 Sponsorship Prospectus)
-  /Dest 244 0 R
->>
+<</Parent 17 0 R/Next 8 0 R/Prev 2 0 R/Title(About CNG Forum 2026)/Dest 258 0 R>>
 endobj
-
 4 0 obj
-<<
-  /Parent 3 0 R
-  /Next 5 0 R
-  /Title (About Cloud-Native Geospatial Forum (CNG))
-  /Dest 230 0 R
->>
+<</Parent 8 0 R/Next 5 0 R/Title(YouTube recording sponsor - $25,000)/Dest 259 0 R>>
 endobj
-
 5 0 obj
-<<
-  /Parent 3 0 R
-  /Next 6 0 R
-  /Prev 4 0 R
-  /Title (About CNG Forum 2026)
-  /Dest 231 0 R
->>
+<</Parent 8 0 R/Next 6 0 R/Prev 4 0 R/Title(Gala & awards host - $20,000 (SOLD))/Dest 260 0 R>>
 endobj
-
 6 0 obj
-<<
-  /Parent 3 0 R
-  /Next 11 0 R
-  /Prev 5 0 R
-  /First 7 0 R
-  /Last 10 0 R
-  /Count -4
-  /Title (Flagship sponsorships)
-  /Dest 236 0 R
->>
+<</Parent 8 0 R/Next 7 0 R/Prev 5 0 R/Title(Hospitality host - $20,000)/Dest 261 0 R>>
 endobj
-
 7 0 obj
-<<
-  /Parent 6 0 R
-  /Next 8 0 R
-  /Title <FEFF0059006F007500540075006200650020007200650063006F007200640069006E0067002000730070006F006E0073006F0072002020140020002400320035002C003000300030>
-  /Dest 232 0 R
->>
+<</Parent 8 0 R/Prev 6 0 R/Title(Welcome reception host - $15,000)/Dest 262 0 R>>
 endobj
-
 8 0 obj
-<<
-  /Parent 6 0 R
-  /Next 9 0 R
-  /Prev 7 0 R
-  /Title <FEFF00470061006C006100200026002000610077006100720064007300200068006F00730074002020140020002400320030002C003000300030002000280053004F004C00440020002D0020005400610079006C006F0072002000470065006F007300700061007400690061006C0029>
-  /Dest 233 0 R
->>
+<</Parent 17 0 R/Next 9 0 R/Prev 3 0 R/First 4 0 R/Last 7 0 R/Count -4/Title(Flagship sponsorships)/Dest 263 0 R>>
 endobj
-
 9 0 obj
-<<
-  /Parent 6 0 R
-  /Next 10 0 R
-  /Prev 8 0 R
-  /Title <FEFF0048006F00730070006900740061006C00690074007900200068006F00730074002020140020002400320030002C003000300030>
-  /Dest 234 0 R
->>
+<</Parent 17 0 R/Next 13 0 R/Prev 8 0 R/Title(CNG 2026 Community Partner - $5,000)/Dest 264 0 R>>
 endobj
-
 10 0 obj
-<<
-  /Parent 6 0 R
-  /Prev 9 0 R
-  /Title <FEFF00570065006C0063006F006D006500200072006500630065007000740069006F006E00200068006F00730074002020140020002400310035002C003000300030>
-  /Dest 235 0 R
->>
+<</Parent 13 0 R/Next 11 0 R/Title(Branded lanyard sponsor - $7,000 (SOLD))/Dest 265 0 R>>
 endobj
-
 11 0 obj
-<<
-  /Parent 3 0 R
-  /Next 12 0 R
-  /Prev 6 0 R
-  /Title <FEFF0043004E00470020003200300032003600200043006F006D006D0075006E00690074007900200050006100720074006E0065007200202014002000240035002C003000300030>
-  /Dest 237 0 R
->>
+<</Parent 13 0 R/Next 12 0 R/Prev 10 0 R/Title(Exhibitor - $4,000)/Dest 266 0 R>>
 endobj
-
 12 0 obj
-<<
-  /Parent 3 0 R
-  /Next 16 0 R
-  /Prev 11 0 R
-  /First 13 0 R
-  /Last 15 0 R
-  /Count -3
-  /Title (Other ways to connect)
-  /Dest 241 0 R
->>
+<</Parent 13 0 R/Prev 11 0 R/Title(CNG 2026 Forum scholarship sponsor - $2,500)/Dest 267 0 R>>
 endobj
-
 13 0 obj
-<<
-  /Parent 12 0 R
-  /Next 14 0 R
-  /Title <FEFF004200720061006E0064006500640020006C0061006E0079006100720064002000730070006F006E0073006F007200202014002000240037002C003000300030002000280053004F004C00440029>
-  /Dest 238 0 R
->>
+<</Parent 17 0 R/Next 14 0 R/Prev 9 0 R/First 10 0 R/Last 12 0 R/Count -3/Title(Other ways to connect)/Dest 268 0 R>>
 endobj
-
 14 0 obj
-<<
-  /Parent 12 0 R
-  /Next 15 0 R
-  /Prev 13 0 R
-  /Title <FEFF0045007800680069006200690074006F007200202014002000240034002C003000300030>
-  /Dest 239 0 R
->>
+<</Parent 17 0 R/Next 15 0 R/Prev 13 0 R/Title(CNG Organizational Membership - $5,000/year)/Dest 269 0 R>>
 endobj
-
 15 0 obj
-<<
-  /Parent 12 0 R
-  /Prev 14 0 R
-  /Title <FEFF0043004E00470020003200300032003600200046006F00720075006D0020007300630068006F006C006100720073006800690070002000730070006F006E0073006F007200202014002000240032002C003500300030>
-  /Dest 240 0 R
->>
+<</Parent 17 0 R/Next 16 0 R/Prev 14 0 R/Title(Why sponsor CNG Forum)/Dest 270 0 R>>
 endobj
-
 16 0 obj
-<<
-  /Parent 3 0 R
-  /Next 17 0 R
-  /Prev 12 0 R
-  /Title (Why sponsor CNG Forum)
-  /Dest 242 0 R
->>
+<</Parent 17 0 R/Prev 15 0 R/Title(Get in touch)/Dest 271 0 R>>
 endobj
-
 17 0 obj
-<<
-  /Parent 3 0 R
-  /Prev 16 0 R
-  /Title (Get in touch)
-  /Dest 243 0 R
->>
+<</Parent 18 0 R/First 2 0 R/Last 16 0 R/Count -8/Title(CNG Forum 2026 Sponsorship Prospectus)/Dest 272 0 R>>
 endobj
-
 18 0 obj
-<<
-  /Type /StructTreeRoot
-  /RoleMap <<
-    /Datetime /Span
-    /Terms /Part
-    /Title /P
-    /Strong /Span
-    /Em /Span
-  >>
-  /K [26 0 R]
-  /ParentTree <<
-    /Nums [0 205 0 R 1 19 0 R 2 20 0 R 3 21 0 R 4 22 0 R 5 23 0 R 6 24 0 R 7 32 0 R 8 25 0 R]
-  >>
-  /ParentTreeNextKey 9
->>
+<</Type/Outlines/First 17 0 R/Last 17 0 R/Count 1>>
 endobj
-
 19 0 obj
-[209 0 R 208 0 R 208 0 R 207 0 R 206 0 R 203 0 R 203 0 R 203 0 R]
+<</Type/StructTreeRoot/RoleMap<</Datetime/Span/Terms/Part/Title/P/Strong/Span/Em/Span>>/K[251 0 R]/ParentTree<</Nums[0 33 0 R 1 20 0 R 2 21 0 R 3 22 0 R 4 23 0 R 5 158 0 R 6 24 0 R 7 25 0 R 8 235 0 R 9 26 0 R 10 27 0 R 11 245 0 R 12 28 0 R]>>/ParentTreeNextKey 13>>
 endobj
-
 20 0 obj
-[202 0 R 201 0 R 201 0 R 201 0 R 201 0 R 200 0 R 199 0 R 199 0 R 199 0 R 199 0 R 199 0 R 198 0 R 196 0 R 195 0 R 194 0 R 192 0 R 191 0 R 190 0 R 190 0 R 190 0 R 188 0 R 187 0 R 186 0 R 186 0 R]
+[29 0 R 30 0 R 30 0 R 31 0 R 32 0 R]
 endobj
-
 21 0 obj
-[183 0 R 182 0 R 182 0 R 182 0 R 181 0 R 180 0 R 178 0 R 178 0 R 178 0 R 177 0 R 176 0 R 176 0 R 174 0 R 173 0 R 171 0 R 170 0 R 170 0 R 168 0 R 167 0 R 165 0 R 164 0 R 164 0 R 162 0 R 161 0 R 159 0 R 158 0 R 156 0 R 155 0 R 152 0 R 151 0 R 149 0 R 149 0 R 149 0 R 149 0 R]
+[35 0 R 36 0 R 36 0 R 36 0 R 36 0 R 37 0 R 38 0 R 38 0 R 38 0 R 38 0 R 38 0 R 39 0 R 41 0 R 42 0 R 43 0 R 45 0 R 46 0 R 47 0 R 47 0 R 47 0 R 49 0 R 50 0 R 51 0 R 51 0 R]
 endobj
-
 22 0 obj
-[148 0 R 147 0 R 145 0 R 145 0 R 145 0 R 144 0 R 143 0 R 143 0 R 141 0 R 140 0 R 138 0 R 137 0 R 135 0 R 134 0 R 134 0 R 132 0 R 131 0 R 129 0 R 128 0 R 126 0 R 125 0 R 122 0 R 121 0 R 119 0 R 119 0 R 119 0 R 118 0 R 117 0 R 117 0 R 115 0 R 114 0 R 112 0 R 111 0 R 111 0 R 109 0 R 108 0 R 106 0 R 105 0 R]
+[54 0 R 55 0 R 55 0 R 55 0 R 56 0 R 57 0 R 59 0 R 59 0 R 59 0 R 60 0 R 61 0 R 61 0 R 63 0 R 64 0 R 66 0 R 67 0 R 67 0 R 69 0 R 70 0 R 72 0 R 73 0 R 73 0 R 75 0 R 76 0 R 78 0 R 79 0 R 81 0 R 82 0 R 85 0 R 86 0 R 88 0 R 88 0 R 88 0 R 88 0 R]
 endobj
-
 23 0 obj
-[103 0 R 102 0 R 99 0 R 98 0 R 98 0 R 98 0 R 98 0 R 98 0 R 97 0 R 96 0 R 94 0 R 93 0 R 91 0 R 90 0 R 88 0 R 87 0 R 87 0 R 84 0 R 83 0 R 82 0 R 81 0 R 77 0 R 77 0 R 77 0 R 77 0 R 76 0 R 75 0 R 75 0 R]
+[89 0 R 90 0 R 92 0 R 92 0 R 92 0 R 93 0 R 94 0 R 94 0 R 96 0 R 97 0 R 99 0 R 100 0 R 102 0 R 103 0 R 103 0 R 105 0 R 106 0 R 108 0 R 109 0 R 111 0 R 112 0 R 115 0 R 116 0 R 118 0 R 118 0 R 118 0 R 119 0 R 120 0 R 120 0 R 122 0 R 123 0 R 125 0 R 126 0 R 126 0 R 128 0 R 129 0 R 131 0 R 132 0 R]
 endobj
-
 24 0 obj
-[73 0 R 73 0 R 73 0 R 72 0 R 71 0 R 71 0 R 69 0 R 68 0 R 68 0 R 66 0 R 65 0 R 63 0 R 62 0 R 60 0 R 59 0 R 56 0 R 55 0 R 55 0 R 55 0 R 55 0 R 55 0 R 54 0 R 53 0 R 53 0 R 51 0 R 50 0 R 50 0 R 48 0 R 47 0 R 45 0 R 44 0 R 44 0 R 42 0 R 41 0 R]
+[134 0 R 135 0 R 138 0 R 139 0 R 141 0 R 141 0 R 141 0 R 141 0 R 141 0 R 141 0 R 142 0 R 143 0 R 145 0 R 146 0 R 148 0 R 149 0 R 149 0 R 151 0 R 152 0 R 154 0 R 155 0 R 155 0 R 159 0 R 158 0 R 159 0 R 160 0 R 161 0 R 162 0 R 164 0 R 164 0 R 164 0 R 164 0 R]
 endobj
-
 25 0 obj
-[38 0 R 37 0 R 37 0 R 37 0 R 37 0 R 37 0 R 37 0 R 37 0 R 37 0 R 37 0 R 37 0 R 36 0 R 36 0 R 36 0 R 35 0 R 34 0 R 34 0 R 33 0 R 31 0 R 32 0 R 30 0 R 28 0 R 28 0 R 28 0 R]
+[165 0 R 166 0 R 166 0 R 168 0 R 168 0 R 168 0 R 169 0 R 170 0 R 170 0 R 172 0 R 173 0 R 173 0 R 175 0 R 176 0 R 178 0 R 179 0 R 181 0 R 182 0 R 185 0 R 186 0 R 188 0 R 188 0 R 188 0 R 188 0 R 188 0 R 189 0 R 190 0 R 190 0 R 192 0 R 193 0 R 193 0 R 195 0 R 196 0 R 198 0 R 199 0 R 199 0 R]
 endobj
-
 26 0 obj
-<<
-  /Type /StructElem
-  /S /Document
-  /P 18 0 R
-  /K [209 0 R 208 0 R 204 0 R 203 0 R 202 0 R 201 0 R 200 0 R 199 0 R 197 0 R 184 0 R 183 0 R 182 0 R 181 0 R 179 0 R 178 0 R 153 0 R 152 0 R 150 0 R 149 0 R 148 0 R 146 0 R 145 0 R 123 0 R 122 0 R 120 0 R 119 0 R 100 0 R 99 0 R 98 0 R 85 0 R 84 0 R 83 0 R 82 0 R 78 0 R 77 0 R 76 0 R 74 0 R 73 0 R 57 0 R 56 0 R 55 0 R 39 0 R 38 0 R 37 0 R 36 0 R 35 0 R 34 0 R 31 0 R 29 0 R 27 0 R]
->>
+[201 0 R 202 0 R 205 0 R 205 0 R 207 0 R 207 0 R 207 0 R 207 0 R 207 0 R 206 0 R 206 0 R 207 0 R 208 0 R 210 0 R 211 0 R 212 0 R 212 0 R 212 0 R 214 0 R 215 0 R 216 0 R 216 0 R 218 0 R 219 0 R 220 0 R 220 0 R 222 0 R 223 0 R 224 0 R 224 0 R 226 0 R 227 0 R 228 0 R 228 0 R 230 0 R 231 0 R 232 0 R 236 0 R 236 0 R 235 0 R 236 0 R]
 endobj
-
 27 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [28 0 R]
->>
+[237 0 R 238 0 R 238 0 R 238 0 R]
 endobj
-
 28 0 obj
-<<
-  /Type /StructElem
-  /S /Em
-  /P 27 0 R
-  /K [21 22 23]
-  /Pg 259 0 R
->>
+[239 0 R 240 0 R 240 0 R 240 0 R 240 0 R 240 0 R 240 0 R 240 0 R 240 0 R 240 0 R 240 0 R 241 0 R 241 0 R 241 0 R 242 0 R 243 0 R 243 0 R 244 0 R 246 0 R 245 0 R 247 0 R 249 0 R 249 0 R 249 0 R]
 endobj
-
 29 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [30 0 R]
->>
+<</Type/StructElem/S/Figure/P 251 0 R/A[<</O/Layout/Placement/Block>>]/K[0]/Pg 291 0 R>>
 endobj
-
 30 0 obj
-<<
-  /Type /StructElem
-  /S /Em
-  /P 29 0 R
-  /K [20]
-  /Pg 259 0 R
->>
+<</Type/StructElem/S/H1/P 251 0 R/T(CNG Forum 2026 Sponsorship Prospectus)/K[1 2]/Pg 291 0 R>>
 endobj
-
 31 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [33 0 R 18 32 0 R]
-  /Pg 259 0 R
->>
+<</Type/StructElem/S/Strong/P 34 0 R/K[3]/Pg 291 0 R>>
 endobj
-
 32 0 obj
-<<
-  /Type /StructElem
-  /S /Link
-  /P 31 0 R
-  /K [19 <<
-    /Type /OBJR
-    /Pg 259 0 R
-    /Obj 258 0 R
-  >>]
-  /Pg 259 0 R
->>
+<</Type/StructElem/S/Strong/P 33 0 R/K[4]/Pg 291 0 R>>
 endobj
-
 33 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 31 0 R
-  /K [17]
-  /Pg 259 0 R
->>
+<</Type/StructElem/S/Link/P 34 0 R/K[32 0 R<</Type/OBJR/Pg 291 0 R/Obj 252 0 R>>]>>
 endobj
-
 34 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [15 16]
-  /Pg 259 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[31 0 R 33 0 R]>>
 endobj
-
 35 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 26 0 R
-  /T (Get in touch)
-  /K [14]
-  /Pg 259 0 R
->>
+<</Type/StructElem/S/H2/P 251 0 R/T(About Cloud-Native Geospatial Forum (CNG))/K[0]/Pg 292 0 R>>
 endobj
-
 36 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [11 12 13]
-  /Pg 259 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[1 2 3 4]/Pg 292 0 R>>
 endobj
-
 37 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [1 2 3 4 5 6 7 8 9 10]
-  /Pg 259 0 R
->>
+<</Type/StructElem/S/H2/P 251 0 R/T(About CNG Forum 2026)/K[5]/Pg 292 0 R>>
 endobj
-
 38 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 26 0 R
-  /T (Why sponsor CNG Forum)
-  /K [0]
-  /Pg 259 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[6 7 8 9 10]/Pg 292 0 R>>
 endobj
-
 39 0 obj
-<<
-  /Type /StructElem
-  /S /L
-  /P 26 0 R
-  /A [<<
-    /O /List
-    /ListNumbering /Circle
-  >>]
-  /K [52 0 R 49 0 R 46 0 R 43 0 R 40 0 R]
->>
+<</Type/StructElem/S/Strong/P 40 0 R/K[11]/Pg 292 0 R>>
 endobj
-
 40 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 39 0 R
-  /K [42 0 R 41 0 R]
->>
+<</Type/StructElem/S/P/P 251 0 R/K[39 0 R]>>
 endobj
-
 41 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 40 0 R
-  /K [33]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/Lbl/P 44 0 R/K[12]/Pg 292 0 R>>
 endobj
-
 42 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 40 0 R
-  /K [32]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/Strong/P 43 0 R/K[13]/Pg 292 0 R>>
 endobj
-
 43 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 39 0 R
-  /K [45 0 R 44 0 R]
->>
+<</Type/StructElem/S/LBody/P 44 0 R/K[42 0 R 14]/Pg 292 0 R>>
 endobj
-
 44 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 43 0 R
-  /K [30 31]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/LI/P 53 0 R/K[41 0 R 43 0 R]>>
 endobj
-
 45 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 43 0 R
-  /K [29]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/Lbl/P 48 0 R/K[15]/Pg 292 0 R>>
 endobj
-
 46 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 39 0 R
-  /K [48 0 R 47 0 R]
->>
+<</Type/StructElem/S/Strong/P 47 0 R/K[16]/Pg 292 0 R>>
 endobj
-
 47 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 46 0 R
-  /K [28]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/LBody/P 48 0 R/K[46 0 R 17 18 19]/Pg 292 0 R>>
 endobj
-
 48 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 46 0 R
-  /K [27]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/LI/P 53 0 R/K[45 0 R 47 0 R]>>
 endobj
-
 49 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 39 0 R
-  /K [51 0 R 50 0 R]
->>
+<</Type/StructElem/S/Lbl/P 52 0 R/K[20]/Pg 292 0 R>>
 endobj
-
 50 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 49 0 R
-  /K [25 26]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/Strong/P 51 0 R/K[21]/Pg 292 0 R>>
 endobj
-
 51 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 49 0 R
-  /K [24]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/LBody/P 52 0 R/K[50 0 R 22 23]/Pg 292 0 R>>
 endobj
-
 52 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 39 0 R
-  /K [54 0 R 53 0 R]
->>
+<</Type/StructElem/S/LI/P 53 0 R/K[49 0 R 51 0 R]>>
 endobj
-
 53 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 52 0 R
-  /K [22 23]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/L/P 251 0 R/A[<</O/List/ListNumbering/Circle>>]/K[44 0 R 48 0 R 52 0 R]>>
 endobj
-
 54 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 52 0 R
-  /K [21]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/H2/P 251 0 R/T(Flagship sponsorships)/K[0]/Pg 293 0 R>>
 endobj
-
 55 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [16 17 18 19 20]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[1 2 3]/Pg 293 0 R>>
 endobj
-
 56 0 obj
-<<
-  /Type /StructElem
-  /S /H3
-  /P 26 0 R
-  /T <FEFF0043004E00470020003200300032003600200046006F00720075006D0020007300630068006F006C006100720073006800690070002000730070006F006E0073006F007200202014002000240032002C003500300030>
-  /K [15]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/H3/P 251 0 R/T(YouTube recording sponsor - $25,000)/K[4]/Pg 293 0 R>>
 endobj
-
 57 0 obj
-<<
-  /Type /StructElem
-  /S /L
-  /P 26 0 R
-  /A [<<
-    /O /List
-    /ListNumbering /Circle
-  >>]
-  /K [70 0 R 67 0 R 64 0 R 61 0 R 58 0 R]
->>
+<</Type/StructElem/S/Em/P 58 0 R/K[5]/Pg 293 0 R>>
 endobj
-
 58 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 57 0 R
-  /K [60 0 R 59 0 R]
->>
+<</Type/StructElem/S/P/P 251 0 R/K[57 0 R]>>
 endobj
-
 59 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 58 0 R
-  /K [14]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[6 7 8]/Pg 293 0 R>>
 endobj
-
 60 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 58 0 R
-  /K [13]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/Lbl/P 62 0 R/K[9]/Pg 293 0 R>>
 endobj
-
 61 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 57 0 R
-  /K [63 0 R 62 0 R]
->>
+<</Type/StructElem/S/LBody/P 62 0 R/K[10 11]/Pg 293 0 R>>
 endobj
-
 62 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 61 0 R
-  /K [12]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/LI/P 84 0 R/K[60 0 R 61 0 R]>>
 endobj
-
 63 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 61 0 R
-  /K [11]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/Lbl/P 65 0 R/K[12]/Pg 293 0 R>>
 endobj
-
 64 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 57 0 R
-  /K [66 0 R 65 0 R]
->>
+<</Type/StructElem/S/LBody/P 65 0 R/K[13]/Pg 293 0 R>>
 endobj
-
 65 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 64 0 R
-  /K [10]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/LI/P 84 0 R/K[63 0 R 64 0 R]>>
 endobj
-
 66 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 64 0 R
-  /K [9]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/Lbl/P 68 0 R/K[14]/Pg 293 0 R>>
 endobj
-
 67 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 57 0 R
-  /K [69 0 R 68 0 R]
->>
+<</Type/StructElem/S/LBody/P 68 0 R/K[15 16]/Pg 293 0 R>>
 endobj
-
 68 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 67 0 R
-  /K [7 8]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/LI/P 84 0 R/K[66 0 R 67 0 R]>>
 endobj
-
 69 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 67 0 R
-  /K [6]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/Lbl/P 71 0 R/K[17]/Pg 293 0 R>>
 endobj
-
 70 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 57 0 R
-  /K [72 0 R 71 0 R]
->>
+<</Type/StructElem/S/LBody/P 71 0 R/K[18]/Pg 293 0 R>>
 endobj
-
 71 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 70 0 R
-  /K [4 5]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/LI/P 84 0 R/K[69 0 R 70 0 R]>>
 endobj
-
 72 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 70 0 R
-  /K [3]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/Lbl/P 74 0 R/K[19]/Pg 293 0 R>>
 endobj
-
 73 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [0 1 2]
-  /Pg 256 0 R
->>
+<</Type/StructElem/S/LBody/P 74 0 R/K[20 21]/Pg 293 0 R>>
 endobj
-
 74 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [75 0 R]
->>
+<</Type/StructElem/S/LI/P 84 0 R/K[72 0 R 73 0 R]>>
 endobj
-
 75 0 obj
-<<
-  /Type /StructElem
-  /S /Em
-  /P 74 0 R
-  /K [26 27]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/Lbl/P 77 0 R/K[22]/Pg 293 0 R>>
 endobj
-
 76 0 obj
-<<
-  /Type /StructElem
-  /S /H3
-  /P 26 0 R
-  /T <FEFF0045007800680069006200690074006F007200202014002000240034002C003000300030>
-  /K [25]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/LBody/P 77 0 R/K[23]/Pg 293 0 R>>
 endobj
-
 77 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [21 22 23 24]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/LI/P 84 0 R/K[75 0 R 76 0 R]>>
 endobj
-
 78 0 obj
-<<
-  /Type /StructElem
-  /S /Table
-  /P 26 0 R
-  /K [79 0 R]
->>
+<</Type/StructElem/S/Lbl/P 80 0 R/K[24]/Pg 293 0 R>>
 endobj
-
 79 0 obj
-<<
-  /Type /StructElem
-  /S /TR
-  /P 78 0 R
-  /K [80 0 R]
->>
+<</Type/StructElem/S/LBody/P 80 0 R/K[25]/Pg 293 0 R>>
 endobj
-
 80 0 obj
-<<
-  /Type /StructElem
-  /S /TD
-  /P 79 0 R
-  /A [<<
-    /O /Table
-    /Headers []
-  >> <<
-    /O /Layout
-    /BorderColor [0.8784314 0.87058824 0.85882354]
-    /BorderStyle [/None /Solid /None /None]
-    /BorderThickness [0 1 0 0]
-  >>]
-  /K [81 0 R]
->>
+<</Type/StructElem/S/LI/P 84 0 R/K[78 0 R 79 0 R]>>
 endobj
-
 81 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 80 0 R
-  /K [20]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/Lbl/P 83 0 R/K[26]/Pg 293 0 R>>
 endobj
-
 82 0 obj
-<<
-  /Type /StructElem
-  /S /H3
-  /P 26 0 R
-  /T <FEFF004200720061006E0064006500640020006C0061006E0079006100720064002000730070006F006E0073006F007200202014002000240037002C003000300030002000280053004F004C00440029>
-  /K [19]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/LBody/P 83 0 R/K[27]/Pg 293 0 R>>
 endobj
-
 83 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 26 0 R
-  /T (Other ways to connect)
-  /K [18]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/LI/P 84 0 R/K[81 0 R 82 0 R]>>
 endobj
-
 84 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [17]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/L/P 251 0 R/A[<</O/List/ListNumbering/Circle>>]/K[62 0 R 65 0 R 68 0 R 71 0 R 74 0 R 77 0 R 80 0 R 83 0 R]>>
 endobj
-
 85 0 obj
-<<
-  /Type /StructElem
-  /S /L
-  /P 26 0 R
-  /A [<<
-    /O /List
-    /ListNumbering /Circle
-  >>]
-  /K [95 0 R 92 0 R 89 0 R 86 0 R]
->>
+<</Type/StructElem/S/H3/P 251 0 R/T(Gala & awards host - $20,000 (SOLD))/K[28]/Pg 293 0 R>>
 endobj
-
 86 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 85 0 R
-  /K [88 0 R 87 0 R]
->>
+<</Type/StructElem/S/Em/P 87 0 R/K[29]/Pg 293 0 R>>
 endobj
-
 87 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 86 0 R
-  /K [15 16]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[86 0 R]>>
 endobj
-
 88 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 86 0 R
-  /K [14]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[30 31 32 33]/Pg 293 0 R>>
 endobj
-
 89 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 85 0 R
-  /K [91 0 R 90 0 R]
->>
+<</Type/StructElem/S/H3/P 251 0 R/T(Hospitality host - $20,000)/K[0]/Pg 294 0 R>>
 endobj
-
 90 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 89 0 R
-  /K [13]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/Em/P 91 0 R/K[1]/Pg 294 0 R>>
 endobj
-
 91 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 89 0 R
-  /K [12]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[90 0 R]>>
 endobj
-
 92 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 85 0 R
-  /K [94 0 R 93 0 R]
->>
+<</Type/StructElem/S/P/P 251 0 R/K[2 3 4]/Pg 294 0 R>>
 endobj
-
 93 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 92 0 R
-  /K [11]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/Lbl/P 95 0 R/K[5]/Pg 294 0 R>>
 endobj
-
 94 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 92 0 R
-  /K [10]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/LBody/P 95 0 R/K[6 7]/Pg 294 0 R>>
 endobj
-
 95 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 85 0 R
-  /K [97 0 R 96 0 R]
->>
+<</Type/StructElem/S/LI/P 114 0 R/K[93 0 R 94 0 R]>>
 endobj
-
 96 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 95 0 R
-  /K [9]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/Lbl/P 98 0 R/K[8]/Pg 294 0 R>>
 endobj
-
 97 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 95 0 R
-  /K [8]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/LBody/P 98 0 R/K[9]/Pg 294 0 R>>
 endobj
-
 98 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [3 4 5 6 7]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/LI/P 114 0 R/K[96 0 R 97 0 R]>>
 endobj
-
 99 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 26 0 R
-  /T <FEFF0043004E00470020003200300032003600200043006F006D006D0075006E00690074007900200050006100720074006E0065007200202014002000240035002C003000300030>
-  /K [2]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/Lbl/P 101 0 R/K[10]/Pg 294 0 R>>
 endobj
-
 100 0 obj
-<<
-  /Type /StructElem
-  /S /L
-  /P 26 0 R
-  /A [<<
-    /O /List
-    /ListNumbering /Circle
-  >>]
-  /K [116 0 R 113 0 R 110 0 R 107 0 R 104 0 R 101 0 R]
->>
+<</Type/StructElem/S/LBody/P 101 0 R/K[11]/Pg 294 0 R>>
 endobj
-
 101 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 100 0 R
-  /K [103 0 R 102 0 R]
->>
+<</Type/StructElem/S/LI/P 114 0 R/K[99 0 R 100 0 R]>>
 endobj
-
 102 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 101 0 R
-  /K [1]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/Lbl/P 104 0 R/K[12]/Pg 294 0 R>>
 endobj
-
 103 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 101 0 R
-  /K [0]
-  /Pg 254 0 R
->>
+<</Type/StructElem/S/LBody/P 104 0 R/K[13 14]/Pg 294 0 R>>
 endobj
-
 104 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 100 0 R
-  /K [106 0 R 105 0 R]
->>
+<</Type/StructElem/S/LI/P 114 0 R/K[102 0 R 103 0 R]>>
 endobj
-
 105 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 104 0 R
-  /K [37]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/Lbl/P 107 0 R/K[15]/Pg 294 0 R>>
 endobj
-
 106 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 104 0 R
-  /K [36]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/LBody/P 107 0 R/K[16]/Pg 294 0 R>>
 endobj
-
 107 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 100 0 R
-  /K [109 0 R 108 0 R]
->>
+<</Type/StructElem/S/LI/P 114 0 R/K[105 0 R 106 0 R]>>
 endobj
-
 108 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 107 0 R
-  /K [35]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/Lbl/P 110 0 R/K[17]/Pg 294 0 R>>
 endobj
-
 109 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 107 0 R
-  /K [34]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/LBody/P 110 0 R/K[18]/Pg 294 0 R>>
 endobj
-
 110 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 100 0 R
-  /K [112 0 R 111 0 R]
->>
+<</Type/StructElem/S/LI/P 114 0 R/K[108 0 R 109 0 R]>>
 endobj
-
 111 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 110 0 R
-  /K [32 33]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/Lbl/P 113 0 R/K[19]/Pg 294 0 R>>
 endobj
-
 112 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 110 0 R
-  /K [31]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/LBody/P 113 0 R/K[20]/Pg 294 0 R>>
 endobj
-
 113 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 100 0 R
-  /K [115 0 R 114 0 R]
->>
+<</Type/StructElem/S/LI/P 114 0 R/K[111 0 R 112 0 R]>>
 endobj
-
 114 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 113 0 R
-  /K [30]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/L/P 251 0 R/A[<</O/List/ListNumbering/Circle>>]/K[95 0 R 98 0 R 101 0 R 104 0 R 107 0 R 110 0 R 113 0 R]>>
 endobj
-
 115 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 113 0 R
-  /K [29]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/H3/P 251 0 R/T(Welcome reception host - $15,000)/K[21]/Pg 294 0 R>>
 endobj
-
 116 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 100 0 R
-  /K [118 0 R 117 0 R]
->>
+<</Type/StructElem/S/Em/P 117 0 R/K[22]/Pg 294 0 R>>
 endobj
-
 117 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 116 0 R
-  /K [27 28]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[116 0 R]>>
 endobj
-
 118 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 116 0 R
-  /K [26]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[23 24 25]/Pg 294 0 R>>
 endobj
-
 119 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [23 24 25]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/Lbl/P 121 0 R/K[26]/Pg 294 0 R>>
 endobj
-
 120 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [121 0 R]
->>
+<</Type/StructElem/S/LBody/P 121 0 R/K[27 28]/Pg 294 0 R>>
 endobj
-
 121 0 obj
-<<
-  /Type /StructElem
-  /S /Em
-  /P 120 0 R
-  /K [22]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/LI/P 137 0 R/K[119 0 R 120 0 R]>>
 endobj
-
 122 0 obj
-<<
-  /Type /StructElem
-  /S /H3
-  /P 26 0 R
-  /T <FEFF00570065006C0063006F006D006500200072006500630065007000740069006F006E00200068006F00730074002020140020002400310035002C003000300030>
-  /K [21]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/Lbl/P 124 0 R/K[29]/Pg 294 0 R>>
 endobj
-
 123 0 obj
-<<
-  /Type /StructElem
-  /S /L
-  /P 26 0 R
-  /A [<<
-    /O /List
-    /ListNumbering /Circle
-  >>]
-  /K [142 0 R 139 0 R 136 0 R 133 0 R 130 0 R 127 0 R 124 0 R]
->>
+<</Type/StructElem/S/LBody/P 124 0 R/K[30]/Pg 294 0 R>>
 endobj
-
 124 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 123 0 R
-  /K [126 0 R 125 0 R]
->>
+<</Type/StructElem/S/LI/P 137 0 R/K[122 0 R 123 0 R]>>
 endobj
-
 125 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 124 0 R
-  /K [20]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/Lbl/P 127 0 R/K[31]/Pg 294 0 R>>
 endobj
-
 126 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 124 0 R
-  /K [19]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/LBody/P 127 0 R/K[32 33]/Pg 294 0 R>>
 endobj
-
 127 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 123 0 R
-  /K [129 0 R 128 0 R]
->>
+<</Type/StructElem/S/LI/P 137 0 R/K[125 0 R 126 0 R]>>
 endobj
-
 128 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 127 0 R
-  /K [18]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/Lbl/P 130 0 R/K[34]/Pg 294 0 R>>
 endobj
-
 129 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 127 0 R
-  /K [17]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/LBody/P 130 0 R/K[35]/Pg 294 0 R>>
 endobj
-
 130 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 123 0 R
-  /K [132 0 R 131 0 R]
->>
+<</Type/StructElem/S/LI/P 137 0 R/K[128 0 R 129 0 R]>>
 endobj
-
 131 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 130 0 R
-  /K [16]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/Lbl/P 133 0 R/K[36]/Pg 294 0 R>>
 endobj
-
 132 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 130 0 R
-  /K [15]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/LBody/P 133 0 R/K[37]/Pg 294 0 R>>
 endobj
-
 133 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 123 0 R
-  /K [135 0 R 134 0 R]
->>
+<</Type/StructElem/S/LI/P 137 0 R/K[131 0 R 132 0 R]>>
 endobj
-
 134 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 133 0 R
-  /K [13 14]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/Lbl/P 136 0 R/K[0]/Pg 295 0 R>>
 endobj
-
 135 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 133 0 R
-  /K [12]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/LBody/P 136 0 R/K[1]/Pg 295 0 R>>
 endobj
-
 136 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 123 0 R
-  /K [138 0 R 137 0 R]
->>
+<</Type/StructElem/S/LI/P 137 0 R/K[134 0 R 135 0 R]>>
 endobj
-
 137 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 136 0 R
-  /K [11]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/L/P 251 0 R/A[<</O/List/ListNumbering/Circle>>]/K[121 0 R 124 0 R 127 0 R 130 0 R 133 0 R 136 0 R]>>
 endobj
-
 138 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 136 0 R
-  /K [10]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/H2/P 251 0 R/T(CNG 2026 Community Partner - $5,000)/K[2]/Pg 295 0 R>>
 endobj
-
 139 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 123 0 R
-  /K [141 0 R 140 0 R]
->>
+<</Type/StructElem/S/Em/P 140 0 R/K[3]/Pg 295 0 R>>
 endobj
-
 140 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 139 0 R
-  /K [9]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[139 0 R]>>
 endobj
-
 141 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 139 0 R
-  /K [8]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[4 5 6 7 8 9]/Pg 295 0 R>>
 endobj
-
 142 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 123 0 R
-  /K [144 0 R 143 0 R]
->>
+<</Type/StructElem/S/Lbl/P 144 0 R/K[10]/Pg 295 0 R>>
 endobj
-
 143 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 142 0 R
-  /K [6 7]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/LBody/P 144 0 R/K[11]/Pg 295 0 R>>
 endobj
-
 144 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 142 0 R
-  /K [5]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/LI/P 157 0 R/K[142 0 R 143 0 R]>>
 endobj
-
 145 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [2 3 4]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/Lbl/P 147 0 R/K[12]/Pg 295 0 R>>
 endobj
-
 146 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [147 0 R]
->>
+<</Type/StructElem/S/LBody/P 147 0 R/K[13]/Pg 295 0 R>>
 endobj
-
 147 0 obj
-<<
-  /Type /StructElem
-  /S /Em
-  /P 146 0 R
-  /K [1]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/LI/P 157 0 R/K[145 0 R 146 0 R]>>
 endobj
-
 148 0 obj
-<<
-  /Type /StructElem
-  /S /H3
-  /P 26 0 R
-  /T <FEFF0048006F00730070006900740061006C00690074007900200068006F00730074002020140020002400320030002C003000300030>
-  /K [0]
-  /Pg 252 0 R
->>
+<</Type/StructElem/S/Lbl/P 150 0 R/K[14]/Pg 295 0 R>>
 endobj
-
 149 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [30 31 32 33]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LBody/P 150 0 R/K[15 16]/Pg 295 0 R>>
 endobj
-
 150 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [151 0 R]
->>
+<</Type/StructElem/S/LI/P 157 0 R/K[148 0 R 149 0 R]>>
 endobj
-
 151 0 obj
-<<
-  /Type /StructElem
-  /S /Em
-  /P 150 0 R
-  /K [29]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/Lbl/P 153 0 R/K[17]/Pg 295 0 R>>
 endobj
-
 152 0 obj
-<<
-  /Type /StructElem
-  /S /H3
-  /P 26 0 R
-  /T <FEFF00470061006C006100200026002000610077006100720064007300200068006F00730074002020140020002400320030002C003000300030002000280053004F004C00440020002D0020005400610079006C006F0072002000470065006F007300700061007400690061006C0029>
-  /K [28]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LBody/P 153 0 R/K[18]/Pg 295 0 R>>
 endobj
-
 153 0 obj
-<<
-  /Type /StructElem
-  /S /L
-  /P 26 0 R
-  /A [<<
-    /O /List
-    /ListNumbering /Circle
-  >>]
-  /K [175 0 R 172 0 R 169 0 R 166 0 R 163 0 R 160 0 R 157 0 R 154 0 R]
->>
+<</Type/StructElem/S/LI/P 157 0 R/K[151 0 R 152 0 R]>>
 endobj
-
 154 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 153 0 R
-  /K [156 0 R 155 0 R]
->>
+<</Type/StructElem/S/Lbl/P 156 0 R/K[19]/Pg 295 0 R>>
 endobj
-
 155 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 154 0 R
-  /K [27]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LBody/P 156 0 R/K[20 21]/Pg 295 0 R>>
 endobj
-
 156 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 154 0 R
-  /K [26]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LI/P 157 0 R/K[154 0 R 155 0 R]>>
 endobj
-
 157 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 153 0 R
-  /K [159 0 R 158 0 R]
->>
+<</Type/StructElem/S/L/P 251 0 R/A[<</O/List/ListNumbering/Circle>>]/K[144 0 R 147 0 R 150 0 R 153 0 R 156 0 R]>>
 endobj
-
 158 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 157 0 R
-  /K [25]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/Link/P 159 0 R/K[23<</Type/OBJR/Pg 295 0 R/Obj 253 0 R>>]/Pg 295 0 R>>
 endobj
-
 159 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 157 0 R
-  /K [24]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[22 158 0 R 24]/Pg 295 0 R>>
 endobj
-
 160 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 153 0 R
-  /K [162 0 R 161 0 R]
->>
+<</Type/StructElem/S/H2/P 251 0 R/T(Other ways to connect)/K[25]/Pg 295 0 R>>
 endobj
-
 161 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 160 0 R
-  /K [23]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/H3/P 251 0 R/T(Branded lanyard sponsor - $7,000 (SOLD))/K[26]/Pg 295 0 R>>
 endobj
-
 162 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 160 0 R
-  /K [22]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/Em/P 163 0 R/K[27]/Pg 295 0 R>>
 endobj
-
 163 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 153 0 R
-  /K [165 0 R 164 0 R]
->>
+<</Type/StructElem/S/P/P 251 0 R/K[162 0 R]>>
 endobj
-
 164 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 163 0 R
-  /K [20 21]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[28 29 30 31]/Pg 295 0 R>>
 endobj
-
 165 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 163 0 R
-  /K [19]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/H3/P 251 0 R/T(Exhibitor - $4,000)/K[0]/Pg 296 0 R>>
 endobj
-
 166 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 153 0 R
-  /K [168 0 R 167 0 R]
->>
+<</Type/StructElem/S/Em/P 167 0 R/K[1 2]/Pg 296 0 R>>
 endobj
-
 167 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 166 0 R
-  /K [18]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[166 0 R]>>
 endobj
-
 168 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 166 0 R
-  /K [17]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[3 4 5]/Pg 296 0 R>>
 endobj
-
 169 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 153 0 R
-  /K [171 0 R 170 0 R]
->>
+<</Type/StructElem/S/Lbl/P 171 0 R/K[6]/Pg 296 0 R>>
 endobj
-
 170 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 169 0 R
-  /K [15 16]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LBody/P 171 0 R/K[7 8]/Pg 296 0 R>>
 endobj
-
 171 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 169 0 R
-  /K [14]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LI/P 184 0 R/K[169 0 R 170 0 R]>>
 endobj
-
 172 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 153 0 R
-  /K [174 0 R 173 0 R]
->>
+<</Type/StructElem/S/Lbl/P 174 0 R/K[9]/Pg 296 0 R>>
 endobj
-
 173 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 172 0 R
-  /K [13]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LBody/P 174 0 R/K[10 11]/Pg 296 0 R>>
 endobj
-
 174 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 172 0 R
-  /K [12]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LI/P 184 0 R/K[172 0 R 173 0 R]>>
 endobj
-
 175 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 153 0 R
-  /K [177 0 R 176 0 R]
->>
+<</Type/StructElem/S/Lbl/P 177 0 R/K[12]/Pg 296 0 R>>
 endobj
-
 176 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 175 0 R
-  /K [10 11]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LBody/P 177 0 R/K[13]/Pg 296 0 R>>
 endobj
-
 177 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 175 0 R
-  /K [9]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LI/P 184 0 R/K[175 0 R 176 0 R]>>
 endobj
-
 178 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [6 7 8]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/Lbl/P 180 0 R/K[14]/Pg 296 0 R>>
 endobj
-
 179 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [180 0 R]
->>
+<</Type/StructElem/S/LBody/P 180 0 R/K[15]/Pg 296 0 R>>
 endobj
-
 180 0 obj
-<<
-  /Type /StructElem
-  /S /Em
-  /P 179 0 R
-  /K [5]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LI/P 184 0 R/K[178 0 R 179 0 R]>>
 endobj
-
 181 0 obj
-<<
-  /Type /StructElem
-  /S /H3
-  /P 26 0 R
-  /T <FEFF0059006F007500540075006200650020007200650063006F007200640069006E0067002000730070006F006E0073006F0072002020140020002400320035002C003000300030>
-  /K [4]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/Lbl/P 183 0 R/K[16]/Pg 296 0 R>>
 endobj
-
 182 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [1 2 3]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LBody/P 183 0 R/K[17]/Pg 296 0 R>>
 endobj
-
 183 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 26 0 R
-  /T (Flagship sponsorships)
-  /K [0]
-  /Pg 250 0 R
->>
+<</Type/StructElem/S/LI/P 184 0 R/K[181 0 R 182 0 R]>>
 endobj
-
 184 0 obj
-<<
-  /Type /StructElem
-  /S /L
-  /P 26 0 R
-  /A [<<
-    /O /List
-    /ListNumbering /Circle
-  >>]
-  /K [193 0 R 189 0 R 185 0 R]
->>
+<</Type/StructElem/S/L/P 251 0 R/A[<</O/List/ListNumbering/Circle>>]/K[171 0 R 174 0 R 177 0 R 180 0 R 183 0 R]>>
 endobj
-
 185 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 184 0 R
-  /K [188 0 R 186 0 R]
->>
+<</Type/StructElem/S/H3/P 251 0 R/T(CNG 2026 Forum scholarship sponsor - $2,500)/K[18]/Pg 296 0 R>>
 endobj
-
 186 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 185 0 R
-  /K [187 0 R 22 23]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/Em/P 187 0 R/K[19]/Pg 296 0 R>>
 endobj
-
 187 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 186 0 R
-  /K [21]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[186 0 R]>>
 endobj
-
 188 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 185 0 R
-  /K [20]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[20 21 22 23 24]/Pg 296 0 R>>
 endobj
-
 189 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 184 0 R
-  /K [192 0 R 190 0 R]
->>
+<</Type/StructElem/S/Lbl/P 191 0 R/K[25]/Pg 296 0 R>>
 endobj
-
 190 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 189 0 R
-  /K [191 0 R 17 18 19]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/LBody/P 191 0 R/K[26 27]/Pg 296 0 R>>
 endobj
-
 191 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 190 0 R
-  /K [16]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/LI/P 204 0 R/K[189 0 R 190 0 R]>>
 endobj
-
 192 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 189 0 R
-  /K [15]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/Lbl/P 194 0 R/K[28]/Pg 296 0 R>>
 endobj
-
 193 0 obj
-<<
-  /Type /StructElem
-  /S /LI
-  /P 184 0 R
-  /K [196 0 R 194 0 R]
->>
+<</Type/StructElem/S/LBody/P 194 0 R/K[29 30]/Pg 296 0 R>>
 endobj
-
 194 0 obj
-<<
-  /Type /StructElem
-  /S /LBody
-  /P 193 0 R
-  /K [195 0 R 14]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/LI/P 204 0 R/K[192 0 R 193 0 R]>>
 endobj
-
 195 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 194 0 R
-  /K [13]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/Lbl/P 197 0 R/K[31]/Pg 296 0 R>>
 endobj
-
 196 0 obj
-<<
-  /Type /StructElem
-  /S /Lbl
-  /P 193 0 R
-  /K [12]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/LBody/P 197 0 R/K[32]/Pg 296 0 R>>
 endobj
-
 197 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [198 0 R]
->>
+<</Type/StructElem/S/LI/P 204 0 R/K[195 0 R 196 0 R]>>
 endobj
-
 198 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 197 0 R
-  /K [11]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/Lbl/P 200 0 R/K[33]/Pg 296 0 R>>
 endobj
-
 199 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [6 7 8 9 10]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/LBody/P 200 0 R/K[34 35]/Pg 296 0 R>>
 endobj
-
 200 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 26 0 R
-  /T (About CNG Forum 2026)
-  /K [5]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/LI/P 204 0 R/K[198 0 R 199 0 R]>>
 endobj
-
 201 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [1 2 3 4]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/Lbl/P 203 0 R/K[0]/Pg 297 0 R>>
 endobj
-
 202 0 obj
-<<
-  /Type /StructElem
-  /S /H2
-  /P 26 0 R
-  /T (About Cloud-Native Geospatial Forum (CNG))
-  /K [0]
-  /Pg 248 0 R
->>
+<</Type/StructElem/S/LBody/P 203 0 R/K[1]/Pg 297 0 R>>
 endobj
-
 203 0 obj
-<<
-  /Type /StructElem
-  /S /Span
-  /P 26 0 R
-  /A [<<
-    /O /Layout
-    /Placement /Block
-  >>]
-  /K [5 6 7]
-  /Pg 246 0 R
->>
+<</Type/StructElem/S/LI/P 204 0 R/K[201 0 R 202 0 R]>>
 endobj
-
 204 0 obj
-<<
-  /Type /StructElem
-  /S /P
-  /P 26 0 R
-  /K [207 0 R 205 0 R]
->>
+<</Type/StructElem/S/L/P 251 0 R/A[<</O/List/ListNumbering/Circle>>]/K[191 0 R 194 0 R 197 0 R 200 0 R 203 0 R]>>
 endobj
-
 205 0 obj
-<<
-  /Type /StructElem
-  /S /Link
-  /P 204 0 R
-  /K [206 0 R <<
-    /Type /OBJR
-    /Pg 246 0 R
-    /Obj 245 0 R
-  >>]
->>
+<</Type/StructElem/S/H2/P 251 0 R/T(CNG Organizational Membership - $5,000/year)/K[2 3]/Pg 297 0 R>>
 endobj
-
 206 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 205 0 R
-  /K [4]
-  /Pg 246 0 R
->>
+<</Type/StructElem/S/Strong/P 207 0 R/K[9 10]/Pg 297 0 R>>
 endobj
-
 207 0 obj
-<<
-  /Type /StructElem
-  /S /Strong
-  /P 204 0 R
-  /K [3]
-  /Pg 246 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[4 5 6 7 8 206 0 R 11]/Pg 297 0 R>>
 endobj
-
 208 0 obj
-<<
-  /Type /StructElem
-  /S /H1
-  /P 26 0 R
-  /T (CNG Forum 2026 Sponsorship Prospectus)
-  /K [1 2]
-  /Pg 246 0 R
->>
+<</Type/StructElem/S/Strong/P 209 0 R/K[12]/Pg 297 0 R>>
 endobj
-
 209 0 obj
-<<
-  /Type /StructElem
-  /S /Figure
-  /P 26 0 R
-  /A [<<
-    /O /Layout
-    /Placement /Block
-  >>]
-  /K [0]
-  /Pg 246 0 R
->>
+<</Type/StructElem/S/P/P 251 0 R/K[208 0 R]>>
 endobj
-
 210 0 obj
-<<
-  /Type /Font
-  /Subtype /Type0
-  /BaseFont /EZZMBT+iAWriterQuattroS-Bold
-  /Encoding /Identity-H
-  /DescendantFonts [211 0 R]
-  /ToUnicode 214 0 R
->>
+<</Type/StructElem/S/Lbl/P 213 0 R/K[13]/Pg 297 0 R>>
 endobj
-
 211 0 obj
-<<
-  /Type /Font
-  /Subtype /CIDFontType2
-  /BaseFont /EZZMBT+iAWriterQuattroS-Bold
-  /CIDSystemInfo <<
-    /Registry (Adobe)
-    /Ordering (Identity)
-    /Supplement 0
-  >>
-  /FontDescriptor 213 0 R
-  /DW 0
-  /CIDToGIDMap /Identity
-  /W [0 3 600 4 4 450 5 6 600 7 7 450 8 8 600 9 9 900 10 17 600 18 18 300 19 21 600 22 22 450 23 27 600 28 28 900 29 33 600 34 34 300 35 49 600 50 50 900 51 55 600 56 56 900 57 57 600 58 58 450 59 59 600 60 60 900 61 61 600]
->>
+<</Type/StructElem/S/Strong/P 212 0 R/K[14]/Pg 297 0 R>>
 endobj
-
 212 0 obj
-<<
-  /Length 11
-  /Filter /FlateDecode
->>
-stream
-xœûÿ #äù
-endstream
+<</Type/StructElem/S/LBody/P 213 0 R/K[211 0 R 15 16 17]/Pg 297 0 R>>
 endobj
-
 213 0 obj
-<<
-  /Type /FontDescriptor
-  /FontName /EZZMBT+iAWriterQuattroS-Bold
-  /Flags 131076
-  /FontBBox [-8 -212 908 811]
-  /ItalicAngle 0
-  /Ascent 780
-  /Descent -220
-  /CapHeight 698
-  /StemV 168.6
-  /CIDSet 212 0 R
-  /FontFile2 215 0 R
->>
+<</Type/StructElem/S/LI/P 234 0 R/K[210 0 R 212 0 R]>>
 endobj
-
 214 0 obj
-<<
-  /Length 1460
-  /Type /CMap
-  /WMode 0
->>
-stream
-%!PS-Adobe-3.0 Resource-CMap
-%%DocumentNeededResources: procset CIDInit
-%%IncludeResource: procset CIDInit
-%%BeginResource: CMap Custom
-%%Title: (Custom Adobe Identity 0)
-%%Version: 1
-%%EndComments
-/CIDInit /ProcSet findresource begin
-12 dict begin
-begincmap
-/CIDSystemInfo 3 dict dup begin
-    /Registry (Adobe) def
-    /Ordering (Identity) def
-    /Supplement 0 def
-end def
-/CMapName /Custom def
-/CMapVersion 1 def
-/CMapType 0 def
-/WMode 0 def
-1 begincodespacerange
-<0000> <FFFF>
-endcodespacerange
-61 beginbfchar
-<0001> <0043>
-<0002> <004E>
-<0003> <0047>
-<0004> <0020>
-<0005> <0046>
-<0006> <006F>
-<0007> <0072>
-<0008> <0075>
-<0009> <006D>
-<000A> <0032>
-<000B> <0030>
-<000C> <0036>
-<000D> <0053>
-<000E> <0070>
-<000F> <006E>
-<0010> <0073>
-<0011> <0068>
-<0012> <0069>
-<0013> <0050>
-<0014> <0065>
-<0015> <0063>
-<0016> <0074>
-<0017> <2013>
-<0018> <0039>
-<0019> <004F>
-<001A> <0062>
-<001B> <007C>
-<001C> <0077>
-<001D> <0064>
-<001E> <002C>
-<001F> <0055>
-<0020> <0061>
-<0021> <002E>
-<0022> <006C>
-<0023> <0076>
-<0024> <0067>
-<0025> <0041>
-<0026> <002D>
-<0027> <0028>
-<0028> <0029>
-<0029> <003A>
-<002A> <0044>
-<002B> <0079>
-<002C> <0031>
-<002D> <0034>
-<002E> <0037>
-<002F> <0045>
-<0030> <0059>
-<0031> <0054>
-<0032> <2014>
-<0033> <0024>
-<0034> <0035>
-<0035> <0026>
-<0036> <004C>
-<0037> <0048>
-<0038> <0057>
-<0039> <0042>
-<003A> <0066>
-<003B> <0078>
-<003C> <004D>
-<003D> <0052>
-endbfchar
-endcmap
-CMapName currentdict /CMap defineresource pop
-end
-end
-%%EndResource
-%%EOF
-endstream
+<</Type/StructElem/S/Lbl/P 217 0 R/K[18]/Pg 297 0 R>>
 endobj
-
 215 0 obj
-<<
-  /Length 7990
-  /Filter /FlateDecode
->>
-stream
-xœ­{	p[Ç™æ×ý@ð€ ‘zà@Šxà‚€x	xHâ!JÔÈ	©+ÖeIÖadÅQ,™v;aìd3•Cë™$NÆiPJ"3‡O&Îd&Ù)W2™SÎ¬7qf“ªÔ“xS¸Õý Š’åL¦vÂëÿuÿ¯ûïÿîÿ‘  JqZ'OT;›ð ÿ¸ïØþÃŸê¬z O ®ý‡ÎîûñÆº—€Êç€Zv`ovª®cãÚ óÀ½YåWô‹@è	 ¾‡Ožy†Ø,@ˆ‡ŽNfßùÕoÍÀ#‡³gŽI³=´t PdïM`òÐ² o;zâ¤ùªù'@{€«ÇŽï=6ýß¿™Úß ð3üç?ŸÀ'pGè@e`!Fo.ÌSÛÂüBìŽ±7iùâèoh¿÷c£ô&á¿»ðoÏö¦˜OGºp~¬ÆjlÁ
-ò @N/üáî~:GÖÓ—I`ÐU†­©´ªß@Å¦a¦LìH±kLgö©Ó[SŒú³/Z`Áä¤¶Çãõ2¤’Zÿ,’™Dˆ©™}!FuÍ«yCLÒÕ©k’Ó…D’9’j&“ÈQg2‘óKIF“[Î¨¬Lc4™ÌN1yüÌ,¥4™I0ïÞ^Þ;[á"‰*£I-1ë Žd&¡1Œ§ö¦g«Ç1YgR¹’)¾«J&uJe/39°c¶‘”'&˜2ò2ÉŸÞ|_Ê«y=Ó)•§¼,žö¨,Æ¡X:­æììkOyw*kåã­óåñ”ºOžÎªÌ:žÊxT¦ò1+‡:9Ô™ñdÒé´‡Q?+KN2lN1sd/+Kz†Y‡ê†³7l˜ä7LØ“NOeÓŒÓéÂÒê«Jj‰tˆ™tu@e²?;¥2sr<ÅÌZ‚Y´„ÇëM3’	1E°›IAu*gÞ“Pù ß®Ç Ÿ_™’˜d¦&¯Ê,IuZf$˜k5ù™Ø”ÊŒ{²›Ó)-íM«,>‘b$èá|)bf•$ƒ³ †˜-:+ÑšÊ %²ŒîÙÇÈ$#fn
-±]åÔV$'oÈØ£òX<“æ(™~A­UŸ-©@r Ñä]TœRýNE*3f!A!ÉdF˜Ö²\¨‚Ùðp0ÕÃâ‹c’_ËöK”¿ÇãÌ7žâÇïõP×-q­¼ÒÀxÊëÑ¼é&oˆUê9JØT¶?Äl:#Ue•É|•Uj‰4³ñ»Í)•Ù„¼ìºÊl‚)ê“ÓZ–Ù“u:£2»–ÐBl™>¼%•“§úÓ>V¾W;b}xSjxÂèôxÓ>æýN=‡eÉ­©Ü²eIF²	fr“cÔŸÈUò‹úŒTi*“üã©g“ý‰éi•/kkòjŒd‹°ÇçP¿èI³Êä³%‡2ŒÞ)¬÷aphýŒ$úf	!BZ.9Ð-)¶LK¨¬BK°r)™„ÊœZBÍ0’ýZu5$	Î	g2ÃÇrNK=ôÔ§C¬JÏÁ1·ž#¼­Ös”·5zNâír='óÖ£çL¼]¡çÞÖê93oëôœ…·+õ\	oƒºVS2Ã[RšÚÌÈŸq³	1}É`ÕâàÆ`hÉ``qð¸1¨ê`•Á÷Ú0ßëWŒ½ò.ÝŸWÏA†X½ž#¼Õôå­OÏI¼õë9™·=gâmƒžSxÛ¨çÌ¼]¥ç,¼mÒs%¼mÖÕ¡¹-ºšaÕ5©1’áÊ‘åÖØÌ•·Ug-AÖÒbmºª©ï!V-Ó¸‡ÿ£¾ûö¢¬sÊ W=ÖÖ”3×@ª5-v^Âž÷ÂéÐÕˆ <¢£€3ðî5	Þ“Þªë"¤ö÷i±\qñ½vêj:ôô3$³±‹êÍîž‹ýG¨Œ$'c!¶ZÏQTùÕfuˆûFýë§§‡´!-«¦öx¸ûÕ³1B\Î¦ëÒª˜[K0ÙÏd¿@Ë•!ÁJ“Á½ÓÍšªöLÇB¬ûN4µÙ˜)Z¢ˆ­²w.ñM©k²jR=×ä€iy:Á]®5©Nkâ	m0Ã”äÝv›ánÏOr23¥1S2;5žbr2ëa¦d†»¼»ŸÉjªÊä€6˜y4fMòÐeMŠU2ê½Ñçª$3\&–™Þ5+“œ?'Bòg¦
-.õöZéë)òBUUf
-x¡õÄB¬wqˆYÅø 6ÄåRì[d!ßŒÁi†-©fµGóŠÀ[èT9]Q0ÅÏLþõK“Cˆ÷Òö‚´4®òk–P’,Š+Ã3»·\q\×ÔfÎÅAæN¦Æ=›Ó)µ'Ýœk%Î`ˆ­½ct³güŽÑÄ=ŸýcO$uÖücöë¬;8­ª=\Ç¦cïÊ”d3k†Ø€Ø2×Ï€Áù,+ÓÆÖ¹‚jjÚ¬Å
-óê9«ìOùOªôÐÿ/-æ{â~¬G‹y¼KôÅ›.Ð9¤çÐ,režCwÐËeÆ	-ìf‘ëu—aö³àîhfM!¶á=ú‡õˆÓÁ¢M!6¢³ÕM!6Ê¹8 ©Íêà´–-rkLç
-ÍFƒ!¶QŸƒ!6®Ï‚p`“>KDÏf}–ˆž	Ž3±-‡[9¶ql×¯HC,¥_ã9T0ÄÒú5bôíÐ¯£ï>ŽG8´“ã	èÏ8ž€vq<íækC,Ã×ä@–¯É=|MLrœuÁ›â8ØËq8°ãp`¿ «?b]:(èâÐû]º_ÐÅ¡C‚.tqèˆ ‹CGõzxLÜ±x0Ä0ÀµÁ;Î™.îÁ;¡çHç¤rœ)àœÒsè]œõ´¸Oœ1@þÄYäèé9R@8g€áÏ#œ×sè[œï‚¸è G¿h€ýýzŽ1@Žðä—ôÖ,Î÷Aq'Ð5@Ž~Ù 9ú=G
- G˜6@Žð¸>[*R\¦xfe*¤4¯Ç›N'‚Ì²—I¾ñ3Å`â!–BhL*ƒ3VÅ¼OÝ/‰i»L$‰ì‘ÈFY–Í²y™ÝfRj‚¯Ýë·{í*­¾õ¹žgRÙ;óS´ÿÖ7øq|ÕÂ<Ó›¨Fs<Xå²˜eJÈAÀúQP*eùÔ¤1 Õpû}>“µ&Xˆtt†ÛÝæ@@«W\.gU¸½3êV´ÙÇ›~µù‰òÖ¶îH¤»­µü‰æWËæ¾üå¹Wëc];·?´}gW¬þU¾v/@=t¥Ðâ*ßÍn™Pš…$‘Œ‰ë³óM±®:4»f;Âö°]ûNéÅëŸ.½xü ßJçò­ä·9´…yê¥7¡â¯–—QE"#ÃÌ9žâì’‰r
-L²bÚI¢YPº~²L²fBÈ2æ‰7²Y†ù^ˆfs¿œŽ—Úí¿ÏWo³Xë‚~MQ´ú{ñ%Ñ"a»F>YâíÙwøÒ£ÛòDEsK´­³¯­ãô­G'Ûú¾þùë_µ¾³ç¾ÔñÙîÖðûòóýŒt%C‰8…$Si?ÏnîiFMD–ûe.™”pV)ÖåÁ°Ýë_û8ù~þïHuþ-:wî3çò?1ôˆË¼…ÚPŠèñU T{dÔÄU(+œ(+ÊjÊªv”ÂêS¬î¢Ì«\NEëìŒD:·xmzúìÙéé³í±X;ÿ•=}þüÓüw¤oõæÕ}â"ä3ÿBe”Ã¯£D¢dD¬O0È%ß/9¼šM¶.:Â®pg8ìâ‹Øµ¡³ÿ¢c<Ò5Cå|äÊš¶ü<×¡…yê¦2œØ,äüP2âù
-ˆLÉHÚþ2‰2È•{dlÀ˜'^Uè”å~cb ý5»Csh&«gQ ö°Ý#×=òÅ1Ü5²sFú;gfvµvíÛIÆò7ÛÂ™¸õŽ¡‡€´†Ö@ÃÆ¯–P*£¨‡.…È2²”PÎq³‰Š-{â5ààƒ$K	!·ÇÒñRG½Csø}BËW¸ÜFã²kvC0Ú¥r(Ú9b—*·wlšÑü¾ðÌ:­c†–§›£Í=‡'ó_#½á¶FþK¤wŠ7‚î @ƒô&–£!î+/£’d¸ƒ¢H’Ð¼~ŒUû…”¼ÞH´¨æAWÅlöÒ`Þú“®¶}ûŠÔ\:0|xuëXßÉøc_k_×`6ïiß8Ù¹»7ºs´e?$xæi/½)ôRCo¼²…˜$Ùt°¨¢ëGÍBECE—/çJº\[^¿²v‰ª–üQUD"áv—Ë©]½|yzúòåéx,ç¿¾¾¾>á©øïÔ}ÛÙ~Ÿ¸Üh­jm­j¶X˜§«éÜð£3.ã¾w’L¤÷	“ä"¤Y¡t«®ªýÕ¾•µp£*à6[«ƒUN[g4¬(f÷m~ÝEæëgÖl8‘øþ‡žr–TmèëÚÝ™8³1[	wÅ"eýç·ìüÜ#úä_ì–Zº:'×í{puGEG4®èXÍå¸ražêô&Ðo«"”¸%
-J‰‰œð`ëG,õîøƒ~Ã»7D«„ÊwÁ\ã„Ss9«ÜîÍß»´j»ÿ¾ÖÈê`xýŽÔ¥Óc¶®kÞ«w¬ßº³÷ìÖ²ÕáÌªU­!ÀRVyp|êX›¾[­ŸÐü%å•S›û»8O»b´Ú°*¦âVJdTj¢‹Yn0†ƒPˆÉ$TqWÅuÜpxäV,ö4òn”t¼Âáp¨Ž•§Ïg3[=·MˆkG} A³k¸ƒùÝ3f×úîôÁƒéîõ.óñG£mMMTÞÕ»|ùòåX{þ_HKoçxgocÃÇ…í¬ñÌ'F¾"iÑäÜj
-0É”Ò~:æ‰»º¹:º‹#éx9 'œšÃWpç‹äÞ6õµ3K¼•…ÊÏ’.î…òmø ¶…yZEmðspJ\ïÖ‘»uÀŸ/XˆðÑ»U ÖU@ûoÕ‰ø¤Þ¾Ò;1’>ô£ýª7´6é+½›GÓŽ—u„FWxœSyÙàÀ¦·xTO«p»Køö&œÜçPÃ¢€%¼áyA?shŸ;fž¼ËùÝÁ’úfþ•»™²°Àã~N	k
-‹æq‰b ­tV8Œ7B¡ÙÏU¯i	€sYy)¬°ú¼ŠµšÇZC4—]úŽ€¦Š}ÇŽí;½©£©©c;½ÿé<9ÝØ\×ÜŠö…yzR‹x¼×F(±‰ÒÈ T&ûÍÄd*„d‘)†t\.ÀUëZQã†œ–ÛyX•Ëå¹FÔ­(U\®0'eîÊå“'Í:Þµ¹sÜ{d¬gõ¢­eO^xøéÕKÂ=ñí«ÚÉlw»ÅÒÞ-dÑ³0OWRjî™è¹­-5¨þòAEû»Ç?ûÉžã•-í±XGcxÙ±Ú#eO]8ÿô…>¯¿;¼¥£Ë¯Å»“bý&€|’ÎÁ!òYæþ”Ri7OM¹®’C‡·Þl­úU"Kˆ4+v…]©wVl?:6>55söìÇ*œ'6õ¿sâ«_=!öˆyº‚†„º¸|oÛùÄ»)! ¹=@²KVw0ñºzÈógÏ
-Y	ÐvzSøþ–¸n!D&#&žTB&—¤‰F|¬æŽU ààFE1kÑ‘Qˆ  ¿r‡ß¡íïòùgÖü°+éŒ­Ž­wùüþó[…Ç¾_Ð¸4†.ÉíÖÿ?ävÅ0ÙÛÑÑË‹!òì}é³é;Ò¥wˆµ»æi}SøñÓ†ëãÎœÎÜS¼‘L´˜—­0ìü.ß-±ÓpíK‡yz¸Ä¿Ó{ºvû®Ý¥ùþ4×þfþ•¢oßµ‰g'øõÂ)r?}"Ã¬z</ã	šðüÄ`—¥ãÖ%jä¶‡í¿¾0-=òÎÃ/ÒZ÷w6•(ÈˆI&RÑÏÀ—Ëîrqíq¸Ýáh4l\%­¡A3›5éå°Onê¹Ü”}áÇžþdÜ/ùâÿ(-í3ŸyÿnýûO¯\ù)‰IÑ°0Okï’M9‘	Ù7wÈ†Ò»eƒ¬TÌžÕ»†e#ôçÑ‹²±;}—ÍÒóQ•[äwÈ†<v‡lf:;;›Ú¢Ñ¶Å Kún­Ø/Ä"‚ç’ÏâH¨Ž»–È\vµV9ÇþÇ·;òBþëF¼‰Š3â\ü"K”$·YºÇP*ƒõ>§pk»SäA"÷wŒ×þe«ššV•=Óø¾ÉÉ÷5Ò¹ü`G¦õt¹üŽ}çÖ¬9·ü•qÖêX˜§=Ô/Bx2^á"’ì$<«6›¤Bz ƒB1Q…4å,dydœÄBþÑb6o8ãWÝ}·…±oO=õõõ¡z½Á¯ÖÕ¸—ÙÊK-
-¼ÄkµV½Ü<
-	‹hQ¯x!°‹[Î¢l~Ñ¼Z6•oéÙñÖ„Þ®w»7yŽOÜÊYáÎ/tlÔ[VùZƒí‘Íë>½¼¥¹~åºæèdæå
-çý[´¾•uN7u| W0	5ñªE3êÇØ{ñ»´¹òâìììb~@ÜôMX¹¼@È€q\ãªØ1‚³,ÁJ¬²µ*®/œÖÂ®×>:c·yŸ¢[n1›ý< í¥2J„Ü	·:#)»ms%(qÙe×¥¢µ½öâ_$Û,mÉg^¤òë_úÒëü„ÇíI§µÔ†hÂ·
-‡Ìb’ÊUB¨‰€È#Ñ)ßÙY°//L&#”ŽŒš‰¢ŸÖ?ÊU˜ŸDÇ0æfÚx*î‡,rKYüä¸f&
-(QèÁ»X‚•NÇ+kkk›jWœ¾€Vo±®ú¹§,¤z‘;M4¦wÆ§Ú^œ^·1<ÒÝu‡¥~·`¨+O><¼+ÒÝŽ}àÂ…ÄÚwåÏ76\àæéìã|3t‚ÎÁŒRâd€È8 ^÷1qSì'c@©f˜E9£&èmÐÌš#ì š&×ô—‚ÿækßÌÿØÒÿÔç?OçnÒUù·…ž<#ß#gþ´¸þ‰ÿÛ“OŠç^X8E—Ñ·aCÈðï¥XêÞmw»•ôu·ƒ;–eÆ!ŽsÆ­5ÓÈ±]]3S—.MÍtíŠ‘½0ø§ÓûNÿÓ@pú…] \8Ež¿scN2ÀågÈöÂÚ‹ëøŒÜ¢!\G]äù¥ýøÎu£&ÔÃ³¸N $GÈ2Á"A.‡8@;é,°	9ÎõI‘jšúÉ˜µ¤²¼ÄfµùT“µ:è(DU-Ú‰thš=þ³Ç§§ÿÙÞÿþ$»öüó×N}þáÏåÛO1:@eØQ_YYJ¹±qƒE‘Ã­#‹…–EÓ"áöhÔ°;òÂ³ÿî‹ïËÔ–TýàÓÃ-–•o}¡»ëÄò>J~üÌ3F­ ý¢~Ø*&ŠB©b·Ð&¾š¼ûv¬¥vG¡@Æ‹qæ†(?YíúFÉ“™Ïý|æ,ymnø'·^â©(j„¯àç
-Dâí¡
-Ïõ¨D Sì‡¢&%GÍÅ*ÊËÄ¹Àn_f·ðºHÄ!|Íåçe£‰üMRu}ÇŽü—¿]òèEr=?ùèˆa€®²Øü3×Õñg*ñj^W 9.J£bOÜ[ªEbHºø®±t¼€»ÝÎXØ¡¹´ˆ×%=÷›}˜üî4þðÿyäÖwŠµÅ
-Á¿„îª-B–M»yDï7ùÇ?<’/V]^×8ùVþŸI]þ_I£¨2~áŸ[è–bm×j"RÑÛ&—xÛR”º–	oYt·®Ÿ½þ¹–ÎŸ}ý÷äo®>öØÕ|ïï8PÐ¸ðÅ¸]Øúb1œß6±kv¾mrú™Wi#]sëÛtÍ¹sÆ<ƒ˜—úDþÿž9ƒÃëòÒ·oYÈa®ê>LcR*ÐŠ75­òiuî*§Ã^aVd	6.·»'[¹’Oæð“´;b¢£‘°‹WR\Æ	ÚìÒh•;¢¸–\‘[ëû¶÷nuïÚu0südb[SÜ {¼þÁÿåY•hh÷Úò²ýàÆ-÷—<P9’i®øœ¼lßè–“öCt´ÞúléÚüo´’¿´­3öÛ´0O£t*ºã±ºZ»M–MÜR¨‰ÓEî”ejâ‡ae7E^ÚqÄsø}z»Ÿ²ˆ×ldÖFå‡G#d…?‡—–ç¿i+©ÞÐÛ•íŠŸÛúÅÍ‡=Ép´«»=©Ÿ[Nr4úzdudoÿÐ±5nkîèé°´ÅÚì„ÿ¡!(*æévzADp!^e«¤”4›¨DC¾’"5Y‘ù’ÊUU)¨ªq¸±E‘³f¶è‰ûÞ"Ê¼Ï”åÇë¦±tÜ©ë€Ñ;D“ÃîñK¬£>]<£-9Ñ®¤áÎHØ¥)f·&R'qž‘ñ£©Ð©ú•átth¿}Ÿµ¥®Î_Û¹ºU),­{äSãfóXßŽê÷W/Ë¢;£´øÛ65¯GU¿¯Ö´¼y`Ý†¾ì‘dòSÙp×Ï¹Ã+is;õVŠÓR’Gsš¹mC&˜ìFÆbçV¹óY¢Ó¹[ß>wÇûž7I ‘°ßxÅò®·+D¼]_\bÏ>Ëž}–øò?¡sùÿI<üí
-Yxž(æÍöIâ%.QÈ^ô>üÀ"*4RØáG…«¤IšYÒ,Ï&ü’>úWcAÉŸ|êê_§ê%-õËç^y…l4®·ÉCŸøDþQ®FªÓ9”Ã/¯	+ÄDÉˆB­åIpÁ]qG\\5Õ•j]µ·Æ[å¬pWºW©–Å fv‰(æu«5®ÛÐèo÷=~å=ùù¿ïlié\=mk‹ŽÐ¹©mÇ½Š÷ÑÔò_¨.¤½”ÿ‘¿¥¶9ð·Â¾êò_é›…š…$	¯40jâá|7?qŽBQú•1^±ÐkrðJEGñí¯XØµ;wŽ]>Zá<qb†<}b¸Ó	gÅð‰üQ¸ºVÄÓ@\«°šˆ|;}•%£rÀû2×2Ãï7\ªÙaÝß¾þ…h“%ûäõo?¿6dÑDÉO$“¿ËÿïìÀ 7‚S€TIç`ƒ¯µYeþæ‚™‡ºBÂmwØ«DÔ6›
-/åa»f§çÃW>‘>üÙ/Ò/\ý0ùî¾ßÿîH¾…Îå_$C·Éw‹u¶¾‚<Ûã-%D’¹4eH¥ý0™
-a•kUV´Wymf¹µB½ÍìÐ$-º(¸7fxÉmm×cÏ=8°WÝ¶ñªÛ†ûmù_é¤(¼}WìWß |9Oìx>bX‚áöÃvmdf†Ê·ÞÁOé09O		9eª?¾‚'’ Û‹Ç‚¥IeNA?á'—óŸ¦¿üÔ§x2
-üâ÷Ïí®ìù-ÌÒ[\¥XöÔ?óöçõmËæ¿%_•/€ÀÌqÅ‡§-$ÿk@fùÁü?ÈWÅLK?qš‚JSXESè¥)hä€¦0ÎûÈ+âýÒ%Ð4O¡]ISè¦)¬¥)´ñ–èw„¦ÐNSè!¯ ‰·\Oÿ×Ò%ß@Sxž¦¥)tÐ¾Ot1—§0f¢)<ASx¦0ÈÇiJÐêà4Òjh
-á2M¡Zº$ðêhJ¬[ASØiÐ¾ð6Ma”¼‚zš‚[º„SœN¢Z
- 	ðü >²‡L“ÒvzŒ¾"UI‡¤ÈÕò!ùªü‚ü¦©ÝtÜôœéee™2®|CyÓ\gž6?gþËËŸ[>c¹Y²§ä©’/•¼auZÖmÖ+Ö¯ZUÚXº­ôbés¥ß*[Qv¤ìåÕåñò‡Ê¿Wž¯h¯ØSqµâF— —Jz€Šë$€ä­
-$~ÎA)¦y’&— àIœówlÇ0…/ÀâøL–ÑŠ7
-°	Ë‰­ +h"MØ‚N²¥ —à)R\«õty.C=íAGqgq±p*ÚÑŠ6D¡b=…*°Žãš¡"‹#˜‚ŠƒX+0Ž`Rô¯Å!‚ºd¦ân/N`/Žãöb
-Í…ç¶¼“bDÅ&<ˆ,Nâ$Žã(TL £8„)´£­âÛ­ÆvŒ¡[Ì±t†;ŸŸ@hñù?m5u›À9ƒ8Š#‚Åõÿô59Oö	ŽÅ¹Öâ8&q 0ÃdCEŽâ îÇ^·{pGp?t¨G
-ÞžÜW1UØÉ²¢ÇÀ:ˆ½‹{,bnÆQœtÂÞæFÂA!Ž¹{qPÐÅÇOˆøÚ\‚'q]hAN‹¯!½f+½Fv£à·þS÷üo‹8€ ÚÀõv6c+R‡Ô Ø„mÆÂX‡AlÇ,V ØB%bè‡‘ÆøÀÿj¡µhÀN8áÆr4¢Q\ƒÕ(A‚è‚ëqZÁÀÿèaø¾³9•#äÉ4#Æ_ËÁœø0ÒÛáSÐÄïâ»•	e­eµ¼Êâ1+ÖBç^š¦ë•^Ú¦Ô›Dgyâ¥j¸`»XqÑzÑ((mÊÁ‘x	/ãeÄ_Þû"Ïºús>reSŠÅ¯¤øýT®‘ßß°Àè@Ú“kà]s–‹ rüÊä–â ÿÄ+&évšTºiP©5)M7ÈÂ™ü¡Eÿ5Ó”‚þ~ ÿœV¼
-endstream
+<</Type/StructElem/S/Strong/P 216 0 R/K[19]/Pg 297 0 R>>
 endobj
-
 216 0 obj
-<<
-  /Type /Font
-  /Subtype /Type0
-  /BaseFont /ZMFSRC+iAWriterQuattroS-Regular
-  /Encoding /Identity-H
-  /DescendantFonts [217 0 R]
-  /ToUnicode 220 0 R
->>
+<</Type/StructElem/S/LBody/P 217 0 R/K[215 0 R 20 21]/Pg 297 0 R>>
 endobj
-
 217 0 obj
-<<
-  /Type /Font
-  /Subtype /CIDFontType2
-  /BaseFont /ZMFSRC+iAWriterQuattroS-Regular
-  /CIDSystemInfo <<
-    /Registry (Adobe)
-    /Ordering (Identity)
-    /Supplement 0
-  >>
-  /FontDescriptor 219 0 R
-  /DW 0
-  /CIDToGIDMap /Identity
-  /W [0 5 600 6 6 450 7 7 600 8 8 300 9 10 450 11 12 600 13 13 450 14 17 600 18 18 900 19 28 600 29 29 900 30 33 600 34 34 300 35 47 600 48 49 900 50 61 600 62 62 300 63 67 600 68 68 300 69 72 600 73 73 900]
->>
+<</Type/StructElem/S/LI/P 234 0 R/K[214 0 R 216 0 R]>>
 endobj
-
 218 0 obj
-<<
-  /Length 12
-  /Filter /FlateDecode
->>
-stream
-xœûÿ AJ
-w
-endstream
+<</Type/StructElem/S/Lbl/P 221 0 R/K[22]/Pg 297 0 R>>
 endobj
-
 219 0 obj
-<<
-  /Type /FontDescriptor
-  /FontName /ZMFSRC+iAWriterQuattroS-Regular
-  /Flags 131076
-  /FontBBox [-38 -212 876 780]
-  /ItalicAngle 0
-  /Ascent 780
-  /Descent -220
-  /CapHeight 698
-  /StemV 95.4
-  /CIDSet 218 0 R
-  /FontFile2 221 0 R
->>
+<</Type/StructElem/S/Strong/P 220 0 R/K[23]/Pg 297 0 R>>
 endobj
-
 220 0 obj
-<<
-  /Length 1628
-  /Type /CMap
-  /WMode 0
->>
-stream
-%!PS-Adobe-3.0 Resource-CMap
-%%DocumentNeededResources: procset CIDInit
-%%IncludeResource: procset CIDInit
-%%BeginResource: CMap Custom
-%%Title: (Custom Adobe Identity 0)
-%%Version: 1
-%%EndComments
-/CIDInit /ProcSet findresource begin
-12 dict begin
-begincmap
-/CIDSystemInfo 3 dict dup begin
-    /Registry (Adobe) def
-    /Ordering (Identity) def
-    /Supplement 0 def
-end def
-/CMapName /Custom def
-/CMapVersion 1 def
-/CMapType 0 def
-/WMode 0 def
-1 begincodespacerange
-<0000> <FFFF>
-endcodespacerange
-73 beginbfchar
-<0001> <0053>
-<0002> <0070>
-<0003> <006F>
-<0004> <006E>
-<0005> <0073>
-<0006> <0072>
-<0007> <0068>
-<0008> <0069>
-<0009> <0020>
-<000A> <0074>
-<000B> <0075>
-<000C> <0065>
-<000D> <0066>
-<000E> <0043>
-<000F> <004E>
-<0010> <0047>
-<0011> <0046>
-<0012> <006D>
-<0013> <0032>
-<0014> <0030>
-<0015> <0036>
-<0016> <002C>
-<0017> <2013>
-<0018> <0039>
-<0019> <004F>
-<001A> <0063>
-<001B> <0062>
-<001C> <0061>
-<001D> <0077>
-<001E> <0064>
-<001F> <0055>
-<0020> <002E>
-<0021> <0054>
-<0022> <006C>
-<0023> <0067>
-<0024> <002D>
-<0025> <0076>
-<0026> <0079>
-<0027> <006B>
-<0028> <0052>
-<0029> <0045>
-<002A> <0035>
-<002B> <0031>
-<002C> <0028>
-<002D> <0029>
-<002E> <0033>
-<002F> <0048>
-<0030> <004D>
-<0031> <0057>
-<0032> <0037>
-<0033> <0038>
-<0034> <0078>
-<0035> <007A>
-<0036> <0041>
-<0037> <0059>
-<0038> <201C>
-<0039> <005B>
-<003A> <005D>
-<003B> <201D>
-<003C> <004C>
-<003D> <0044>
-<003E> <0049>
-<003F> <0050>
-<0040> <0026>
-<0041> <0034>
-<0042> <005A>
-<0043> <00FC>
-<0044> <006A>
-<0045> <0042>
-<0046> <003A>
-<0047> <0071>
-<0048> <007C>
-<0049> <0040>
-endbfchar
-endcmap
-CMapName currentdict /CMap defineresource pop
-end
-end
-%%EndResource
-%%EOF
-endstream
+<</Type/StructElem/S/LBody/P 221 0 R/K[219 0 R 24 25]/Pg 297 0 R>>
 endobj
-
 221 0 obj
-<<
-  /Length 9069
-  /Filter /FlateDecode
->>
-stream
-xœ­{	x[×uæ¹÷- ÁXH
-´ôÀG€ñÀ	qˆ;	J”È’HÔB‰’eI–eÙ±y©M×±ÇY:±Ó¤3qO&ö\H^™&öÄ‰²7‰“z2iÓŽçÓLÒ¦IÓ~JÆI%p¾sñ@‘²d;ßWQÄ;ïÝs·sþ{¶€8´î9yBUîðž€¿€¯ì;ºÿð§;? ÷ ”Û÷Ïßµ¯këPñ1€Ï½™YË‘Èï :‘¿óÀ½“@	Ðy ê>qêÕ¦Úµ ]Õ $:ÛžÌ³Bög Á ðôáÌ©£Â3–; 6  ¨G2‡÷ÆÛûs€*€ Go;~âÙjwôª ðÃ£Çö½û¯Ÿ èÅñß†?þßØ1ˆÑE *,éÅ¥ËÔ²ty)¸ªíÒŠÖßí1ˆA ô"Ù‰¿7å¿dð‡ „üäv rçÒ
-÷t‘Ó×I€®2Ø’Œ¥Tuô(ŸeòæíIÖád©ô>uaK’QwæÕ"(‚={´ÝN—‹AŠAD‹ž‘tØÇˆÎÔô>£ºæÒ\>&èêìÁf‡p„Y#j:ÎR[$œuF#Ó§TVª1‰df™˜8užRI‡™ko­Ÿž/·“p­ÊhDŸ·k$Ö$’{Sç9}LÔ™àeöHçcŽHÄ`pª³*{=ÁDÏöó¤,Ûcr,éb‚;µéÖ¤Ks9’*K$’.J9UD*˜J©Ù<wf–5&’.ãNe­ØÞŠœ¯'’ê>ua!£2s"™vªLÅ63RHu¦éT*ådÔÍJ#{lJ2Ef+8GÙZ¤ÖŽf^±ÀäxE‚Ý©Ôl&Åˆ7•2vRg™#¢…S>&éjLe¢;3«2S$‘d&-ÌŠ´°ÓåJ1’ö1™‹›	^u6kÚV±·ëÌ/?™œŽíaR“KeEuA]`Ä›m•ÜLôL%Ó	gfS*©¥\)•…6'ñ:Q.ÆR|Ì¤³âˆ÷<Ð¼š‹tV¬…5•Î0º{#{I3S“ë*®¶<²çv«8¥SÈ’ŽòÕšõóÅå‰…›\ËÀ)ÑW©4?
-ñj"Lt§ÕØ‚–A¥raƒÂT'-Œ	n-ÍOQv“î¬>‘ÄÎ¡u*Gükáe¥ ÄI—Ss¥š\>V¡g)±ÙLÔÇ,:#iUe‘@eZ8Å,x·)©2×—¢«ÌÂ…¢¾"Âž-Ã”HZ]H«LÑÂšUê£ÓÉ¬8MÕ³²½Ú)³ê£SÉÑÍù‡NWªžYùs›ž…ÊÈ–d¶²2ÂH&Ì/9FÝál~X¨;ÌˆCS™àN$³(>&ºÃ*NkiriŒd
-´3ßŽ]¨›?I±ŠÈ ³DÓŒ®VÖMT˜°jQF"úÏB¸¶ì:dÆ¦“¬R«1V®…Y™ÆätXe6-¬¦É¼\]M@+„Ãa”„-’Æ¶¬­ÈËñ:ëR>æÐ³`÷úX•ž%x­Ö³¯5zVÀë=+âÕ©g%¼ÖêY¯·èY^×êÙ"¼®Ó³ÅxõêZALNN'5µ™‘xl|L_ÑèXn¼=ßè[ÑèYn<–oTu`Þ›m÷úb~¯¸Ñ•ûséYP½>V§g	^5=KñZ¯g¼ºõ¬ˆWž•ðÚ ge¼6êY^×ëÙ"¼6éÙb¼6ëj/Gn‹®¦YuZhŒ¤<ÍÞVµxYK“µéª:¨ÞD­Z&¨¡…O'î¾½ ël¹Cè±¶¦¬Dì±dkŠïÒ¿B<7ãéÐÕ _y@ƒ'öî9ñÞp-ø/pí×‚ÙbÇ½vêj¯:x“õ3ˆd‚>Ö¥7WõúXðýX‰ì	úØ=KÁáV›ÕA´Œº‡µA-£&w;ÑüjáóABì¶&ëÖ8X•f¢›‰nÎ–-…0+‰x÷.4kªÚ»ô±žÕljs~<&ká·ÊÒh\BSÉ¢*©Î¢GZ“
-£É5GÔ÷Ðâi&G®?·i4{y÷$FÒ³“"™ÙD’‰‘Œ“I‘4š¼ëûd4Ue¢G‹g‚N™#qt]æŸ%­Þh-o\åH•!¹3Lz×¨Lôà"Ü¸Áž5Lêµ¹R>Ö[…ªªLò²Ðzƒ>Ö·ÜÄÌ¼=®â¤¨Åþeâfò’f0lV{5w¼ÆC×e¨‚Én&¹‡W1y%Þí†¶4„üÆ+‰Ô•ÆHçú-TÒ5µ¥gU‘dÂ¹)•T{SÍÙVbóúØÀªÖMÎÄªÖðû¾WˆÎº½ï5aTg=ÞUíEŒ-oÎÊäH3kõúXŒoñéÉK>ÃJµp~ëPMíU›µ 1~\ÏšEw¸Ðå„ôà¿ŠqOhÇzµ Óµ/®”±ÎA=ÝÞ‚T†ô,ôx]¨3\¨±›eëìùcð„[›Yg“Üäù¨žb³²®&ÓÙ†&G)Æ4µY/h™‚´&t4÷úØ¤~ îõ±„~SúyÂŸlÒÏþd3òz}lyØ‚<HlE$¶é  âõ±¤~c(¯¥ô$ÿl»~äŸÝŠ|©ÈÇ©ÈÇ©]ÈÇ©œ3æõ±4Î‰DçDb7Î‰ÄäòúØ,ò ±yØ‡<HìçëŠz}ì _Rs|]HäëBê_Ró|]HæëBê_R·éYè]VàQ~ÇB^»=Ox}ì
-ß…½>v\ÏƒçDžDž;81xNêYè[õN~Ç{œÊ“Øã®<‰ì§õ,1îÎ“ÈpOžD†éYè_ï^~ÇÙÏäId?›'‘ýÃz–çò$2Ü—'‘á~=—Ç{€ßqöó$²ÿIžDö‡ô,1Î“È°'‘áý|	q™ì</R!–Ô\NW*ö²¢½L¨Oœ*8kºX
-* 
-¥ €	Ö‡<øL º_$!Â6‘™"IQM¢©R±Hr×êR\nÅ¥¨´úê/ÈßæÒBé•Ë½ôcWçø–.Óµô"¸¡9äuØ*%c@)É !Ãã  dpèa ÜP_ïuKæ¯ÃÓÐåpøÛ;ž†'ÐÑéo¯2y<Zl·9ªªv›¬ýðtSßúý£S½ñ‰ôô=‡?3Ú£nîë}éì‰ÒîöŽ¶øÆŽ`i™eïð®ÙCþ&½¯§­»´LýLæîyf)Hk©,°ž©ŒRI$c<‹Õ‚(B†€ø¸L$‰f€Ò‘q„!aÂ9ÊJÉ–âã Š|;c7ä³½ïXï?L*•
-•+Š²V¹Åc­×,&³ÓkõÛýþv.‡ºMÑ 3èàò±Ûþ™„Ø~xæÐ¡™Ãíb‚ÔLLÄ‚ccA*N§;sæ±tî¦“ƒÓÁöÅö ×xé2uPTÀ- ‡Ö¥€±q	UŸ	!#dÂb°Üb©­²C”{ds•×ÁÕƒkÁÅÈZçª…\šÛ°anhˆÆ‰þ–†OoÚt:œÿŒmž™ÚÌ? 1³€\¡°ÂC/
-„
-…XA
-B”DJi”ôP• .“pE³íf=oÚ	…] V°jVM‘Ík¼~¥ lESò[Sv'Äõ7eý½Që¹I_<îoÍ=É÷YºLK©<yìS²
-ûc×cßnM¯çØ_	ýfZ€~ùk)ªüS©NÏöž#­Þ©¶‘Îc»îŸèè<Ô7ÐÖ4Õ>89[º·e}£Ow«r©©¦§ctrsÛ@Scávl8
-@>OE(Wh-%B~q9 D…	«K³ˆæ5Øüv¾síhBò<Ô1><• â¹s‰Ms?[ÖÛ%°BC¨žrÅ@l…„EÂŒbµHÂÊõRÕVŠ5A/å¾»Z°KK”ß¡— F—…PH @Q³°€—Ë¾€|„.‚[2QŒŒË„Ra¡GÉóEÉ„¢(ŠÍ¥™Ì·x»lß¢ÇP´€?à·ûíÚ¿¬Ý°¡¬trÆôhâ©§¾Øê+‰:ÇâÄ}é¥(ÚM;–.“ßQ¬pï‹@()àµR „ÄÇ¹LE0¸:ŒQŒæ›¡Ðj»I¿›uI¥R/+VÍZ‡âtk²Vç	(~ÅÆá£ø<³Bœ	D)Í½Â$û®^áçqj§¨†:èuÛm÷ "*’ý&"I† J…ŒœlM@M]km-TC•fóq£}ÍØ]xøÛ;»ªdY£²l·»Ð(üÓ‘žÞCñè¹s[‡ücöžêÃ#­ñFÒ8*Ÿžšº;2plØSK¶x;ÈO×é¦’è”s€|Ž^2t*ÜBÆÆ%@fÐ:ÅÇA–£òj´^± N­¨G\‡®lG*Úóøg&U6¬}øáy=ê9£%¾ÖŽh.Äu_ºL×Ð‹°Ïn•£¸Hä2!„‹b8/ŠkgwÔ¸Ýù³›÷TŽ‚«Z!„¯Ÿ9sï¶Ìº!ÇÆn4wÝCë2ÛJ_eìÕÍqWW÷ÝóÇæïîîrÅÑATÓ"º%°6ä”â¢ºZÁ„bU*ùáÔMñãaR´ÏšÆîüµiìN:y5K¯¾L‡¯Æ@pé25Ó‹à‚—C%åeT¢@‘H]ˆ‚$î_á˜ÑbÊ«P[w.YŽæYW!øýÆû C¡6+ŠÕí®ç§Ó­ÉÝ7n  ê)Ù†ÂGo¿çC©½Î!G÷¦©‘©ðÄGßžØÙºáåç^XÜuuuŸ><ôÌTx(’û<Ø@+é"sLQD*ìG5Ï`¤=.QŒŠ¨áb(FS‘w.;ÿQ¶“WrŸ"ñÜ"]þåpî¼ÞÒ B=µ@=<öR1¥ÂrDa—	†”P4°&‰rkH·†{#ä ÔòØJÛÍ{¿GGa	[«»ÞRd^›·â\~ùËJ»»L¤¢-ÔÕ9m£–ÉþÉT¢«ÛOtnð%¨8íówš{ò9÷·äž$}ñ^ó{  5ô"Ô (/£‚?6ü¬æQ€’Â„ÃÝÈ=‹ËèZLùuÙd“ÉEkrÍÿì‹„ú+G«ïÚw|rür÷Ö7Û3í¥cýjwÞvëÈ=‘/àÜÇ¸J/‚	ì°-ˆEDDi®`0‡ÇM<”‘ó¡ŒÃQTàXçXë¬)²Ù*ÊÀr]1†4ŠÅß®X®e<@‡¿Ýn·iÁË—/OMáo)™#s¹?ËýÙð]GŽ¹‹üŸVGk«£•ÛØÐÒeZMÁõÐò›‰ˆÞ‘€ á ‡*f$Bé¨ª¨ª¯ÒÖÖ‚ì‡É\·,]~Y6UÝ4ØzíÌè‰þù»î­•j7÷õÍºÅã‰Äà`"1XúØ‡2Ïß×¸í3'hK ˆÎuNÆ‹â“ü|wé89 Õ!;à!Ø†:dR±Psµ×í4B>|<òPî—\ß½¤„Ö’-  ZÑ‡ìÄÕ"(‚¹Êk¸ì½ä‘’‘. ZM/ry´„t—‡DD  ’¹‚qçùA&ªªPÏÈ²Iëììjà¡àqìò*AÐêw	âÈ™Ï¢ ©ëñØ‡¯ÐUXZ¯Ž…>+€#ß8—Äèho.Ëé¥ËT¤¨ÉÇ‹×ùœ±ë}NT¿—Ïá.ç÷Üsx(]*·Ä&&w7m¨ž)}âž{žuÕ5êÛâÉø¶í]£3K—i-½tã\ˆr×%(B¬+r¡•<@®Èd–ƒñ÷ëý‡¹q.¤¬Ì…ìZýÉ…0¸äÉÐtÏªTÈÈ…<%±þ5TR©P*P"É©Y¢ò~1¢86'‘"
-/&&SáfÙ®¿IŸ"RèÂ·<B
-’úã&ù#ÆG:×­#°nýºÆúº[œ›¥¼¤Xa-Yk6;¼®º†|,Ùá÷s93JÓo÷ Ë­ã7äŸ§J¤ú;§Òw$Ô³Kï´ï¹õ½¢þ‰#Ú§ÓÓÃŸð»ÇõÞSïTØã]][&ìM@`@è¢"ØÐWTQ“D" ?C<D)âÜ6›b·ãÉ·VUù»ºüùOA4“Iž
-Dèxß`ÿ$F?ºçõf>FÅoüáÊ×¿~åß.^½B>þ¹ßà«rÔkïÒeòûeŒ—À*Œc4¹—V…@êu<Ëà¼. zï±Þ˜•W¬õu¦kÑ=Oy¨çY…qò_V`<166ŒMLÄŒlŸt\­íáðæ@7âË¥Ë<¾´cþ'
-#K’qÎ Àöz71V“£öNžT ÛáIÒÓÝ7vWL»víÜ¹ËEs;§¶µ·o›"ŸÍÝ~û}‘È}·“Çòsý# ™‡û@€š£”B°ÂE¸íZ€ÌŸ»ï¾ûò}j èFº¦åõÑ ”/2ßÓ&EQp}DÑ-à²“­Óÿ@=ôö«ÑÛ‡‡óãì€?ÐK`Æq€O fŒ š@±IÁLÌ¢Ùáõù“ßo¿ÐèKÔø›Ýô?\½»&Î±£“ßsûÜ —C¥Ž*K²D	-HRÞB›ˆ,sIFÇ|hFnÅ8N!ïÉlû £®ÿà£†ê 3&Ø{SvncS¡Š5kÖ4¬ñx¬õõZ]‘¹ÖëæÖµËáoV‚1à§«¡øûS‡NÄZ:·<!¶Þ5?¿!ù)‘Ê¡Óƒ]Á'·¦=}úÑôt.lÿ"Ârdp<Edòe²ýƒÅO‘:"OOãfòñ„˜ÇŠ@Ð’äË×ìˆ	LVE4W{ý‚ßê·ú…ß¿:õ¤øää«TÌm$ÿ“a¥ Õ¨
-Ô…ÖU”PÂÓq’B†ÈrQ„ø‰,kZÀßÞÕ%p«D~”Xë†àØ­kÍ-?Ø´m\§âÕGZ£Îãä?ùÚ×pŽ9 ÚO/AÔ‡\%fÍûyîö0‰5–l­´¥ÍÉª	&»6—·q÷[ÿ¼ç[)¬Žø¶|úÛ¹‹¤têKyû†ùŒ›.BTA{¨¥˜`ö!…ý IÎ‘È8Íƒ¿¢Üa+¯ª¨R.‹	SM1Âo«&h]˜Zux4My~:—ÞŸÚ|~×n{6ÐÓx–.œÙ²¯(÷&i´u´–ògmûrÎÚÂÝ×uùˆ¢4ƒ†.*¡JJ “*ÍÛrVewÙ·“çsÏ‰Üy²gV—‡qìa^§X„:ð‡ZÕu•
-•pw2
-Dœ i$)‚æ´`Äln·§Þ"›k½Ä%øW„ÍuËõåBæau‘ßæ¾i3Õ†;úÒæ‡û6ªñžÁ‰É!ß†5ƒ5äz{î·OG&ëèlmi™ˆÅ&ÖÞb&g; t=ßûúG–mû²´…4á¨PØ·Û-?&®¦†.,0nù¦‰µ½zß+ÃÔÿtà¹«ï-$¿¦ï€<£¬:‘•`4þ ‚r1Êå ädê…*+Fè•ùÏa•ÖLßîêžÚy×];§ºwÉÇŸ_ðÆß:½õô[qïÂóhÀÁ¥“ä‘Õs ÑR>ò  ,ÏQŸÀQrþµÔNY9Éÿ¼Ñ­K—©L/‚ÑÐ@‰™±	ÔuT”„1,H"H”BÜ/ŠÜ,¼ë1F)/-’A'ºÉìð’z+èÔd¿¡jµ )õ«6?Ò»;8ÚÚÚ{xhú`ÃÆu#}Ã‰‰±Íä‰P‡©³»ÙÛzl}¢+4]!–néÝáç:ŽõõG‡VÕcÐ D€ýXÒÄ:Ár1Q1Ð†%ÅÅKp/ä~3=M,ÓÓ¤/÷]Ì}—t\çår
-@Pè"X0Ë0SJ€ŒÉ 3h"ã˜iD	‚ÆÅª(6<,Ä$FÕÇêW4…>Óóùgzj6û¦ø­s›èØ¹ÖW_¤‹¹‡È©«q:¶ìS…ù‚ÏWŠé/)àTŸvÅn7ª³ÖÿMàÿkR£Ýt ™Þ2 ôNn½°óÖïÜIs,÷oD"‰Ë]!"I\“– ÷t¡.`¥‹P›^4¡-7\f5æÀ@Ž¡ñÊ;wcX×àMÂÙwµ¥B¥Xð…"Ãùû‰ËÎÿsDÉýÕ(y3w™;÷í‘«s‡Ñµt™ºèEpÂzèBüYeŠé¦‰ J‚¸¢<PD$i¹<ÐÔT[ÐÔÕÔÙÖR»¾¶QsÖè¼<ÀÓÎ®€ñ^jü*WùÂÕw?;îœ›»s ™Œ‡ÃÃC‘‘éÍ££›§GJ;vtÇ¶VY·ö$ff=[­E•[cÝ;:ÈŸww–£í-ïìÎ}!Òãè‡{=‘¼^û h-¡<!­Ì,ñš…ü{ ¨€ŠJ{%—™µÁˆ£MV­A3õ½þ¥ôD¿Ø;¾ãË_M?!>JäÜá­[_Íýþ;ß[ðe ¡qŠ¥tà‹{î…™kæ­Š+•ü,âBÅ¸ì[Èxî+ä“¹dÛ89Ï=Eµ€vó¯|¡& ˆûA•Ë÷ñPb..2">“¹ÆëjÐLšÕo%šà'o÷ü¶gÛ[·½•û]ñîï}ãtñjœfrÿ-/€ÒE0ƒR‹%"Dƒ…Ô‚dÌ`¶UbtàR¸+·ú…ÐIÏn¿´ë_H%yö¥Ï-¹dî×€ï ¦È÷Éÿ£— &?‚û˜¼gz{é$ù=}LÏ[R+P‘TØSpÜ¢bÅC”ý@n+H
-“yd_k«—]Süö·Iõ~´ œë¿ò‡~ 0³t’Ü¹zÒíYVDSéÌ¥ðÅÎ~Þ¼ÍXwÍC:¢ ¹3÷‹ýˆ¾såÞ~Aîç;=L¾O­|§|§|§§ h]	Öñ„>‚¡M_“§’’¶ÐÚOM“Qºˆ>â¨ÊmA%¢µPÄãM)GT”L˜‹•ŠâJse½*™«½V#·_’Ì¼qæÌ™3o¼¶iÛ¶M‡è"{î96|âàüÁW²´ó ð:]ŠY¦­ã°7Ôˆ†…
-q¶\é5Vn«,+A4Ô»äüê™eÙ£lÏ¥÷ïOáZ$4s0÷r;ƒ€BÍÒeÚK/B3á‡!«bA·¶55ÔŠ² ¶OÅøH6â£‚ý‘e1c’(/;ÙBý»ùøk d–2ø~fD*$ï?æã[K@K°¥šÁgWœn½Øì,˜¾åºÛŠ¢SU•¿³«Ëo×LX£Ô°bÏëtÜö}z[sol]]Ûæ¶þ¤%\pëë?+™Dúè¨ —•ŸžÙ&Ul‡ÂÖç§‡ºKýÉÎÞy­ql}Û¸w£·ÎÕÐå-Z×Ûþ­õ#Ž–žÇ÷úëÕ7;vVtâ;
-u ´ë¸£Ï2¿Ç’PÑ R8ÀC1¹PÑ/åZV”J_WÀ „iv·KÑÈéÜ³¤ùô¹Ï’2ñáòóœ-öð_‘ÿÊc ÚÈßxBš‰ÒB‰ÛHN¯•¸+•ÊB‰Û0ƒ´1WDÉ=HÞÊ >J=Ã£WŠ§,ÿñM¨ƒ¾—±«°´´ôÓ¥ üÀxÓy”¿é¹îM§ IÙXõXõ6‰bÌOA©„Å â&|E`¯Zg¥¢¹œõµõ5UÊšÊ5ºZtí˜-»2—µ yû5*ù«ÔþnÿÆ¡¶­Üo/uöôt>þéžžOÓÅÝ›zG,BùT,¸#@imihiû¿¹¯tv¬ïèÄýä« ´êð»&ÄÄ?ÿŠ³„¼Bþ”o³ì Ï²oX¡¹öŽãZµäúodPzýW)®ç³½ïXï?ÌûVhÐžÒ^¡™¾ÚA„ë*4¤xé$™¤ï€ Íy;_ÊóàåðßÌÃÜÄÉÞ,gÇ’âWHq|A8wå^ 0°ô'B7ýôÀ0±Ž²æDò%W%•‹É˜	s1K²5X£,5SY ´H¦¡¨„à(Á(Cq±˜Áwbñb”ãºD2ä{ï’Ï÷‚B§æD2Ô
-’X,JÅgß6£_(°Ü…˜ejNÁê‡ZrõöèîŠtÛZÖ7Ôkën©²[Ê‹MÐCzÊÌ¯tí5B¾„ìá¶ëÚS®Nã]c·w\¥X½NÇ¯{n&sþÄžg÷oI5·K¢½Goli™lõ+ÄØš[šÛlÝõÑM“ïüùW:þŽŽŽŽ»ö.ž¾ûµƒSÏÝwô#ÍMzÛž¡¡=mMZ4÷OmzºyëÃ[?qkÏ®'6õho>ÝØÞHú8F¸x‹£&äÈ£öZ±ÇVg0Œ°u
-^¿{Ý?3)É6¬M8×Þ‹î@àwô IÓƒ Yy6ªE¸ÙV(ØXY‚ÉÊ%X³K¤?>xpi	>I/Ó7Á£;sD†ÑÏæ 2ä•¥xñ˜s‚ÏUðÐXC ðâºu2¡XhZ"E›ŸžÆ@ü=ù>ù8½dð^¥ò/¥¾”²}øx„^2ÞJ½A¾OîzoþÎHàÃËüGð/Ï¨¸¼.Ãh×r$‘ "ÿ¾þí¸ïÉñ_ÍTôþLÂ/Pxo•>þ¼þ$~ä­ÜÉ%I|XÄIMÈËÿ ‘ä~ ²ÜÉÜña>ÒÊS4	*M‚&a†&!L“°›&!B¾
-G‘&:dÈWÈW¡&a‡Ñ§Iþ› IÒ$lî‡4MÂ€q¢Iø.MB¯Aã³éÂÂý0n´aÿ¤I¨!:ì2ž=eô	Ð$ÌáØÆï°ñì{4	iZ±¿p?œî‡cî.š„>š„-4	ëhšä{|Û˜û0MÂ)¤‰óÆ¸Ø·ÎoÑ—~J“4ÖÕK“¤X¸Œç¿£Iø¤Ñ÷ïiÞ :×dœÆ¯”’gÉ;T¥ÓtÝG?E¯	áAá›Â¯ÅÓâÓR”–ž—A^#wÊÊ¯›Àô`Q°èXÑ;ÅÍÅCÅóÅ›Ãæ]æsæÌÿ»¤®$Qò%ß.¹RÚ\úxébé¿–5—Í—ý]yyywù|ù'ÊÿSù_W”T8*:*öU©xÚ’¶|ÌòË·,£´)å[Ê¯*ÿÆJ¬.k—uÜº×ú!ëG¹æ§à;P ¿ØññÀ£ äåv0‚XÀU, LŽó43h
-åðZ€8<cÐ"tÂ?´kHAËÐJzº:É¼AÃãä?t	ÔÑvƒ.…::¸ŽÂ]pæ`?€ B;´Bt
-Ã†qP9×18
-Í BŽÀ,¨0œãìáÏ`æA]1Òq~·ŽÃ^8'a/ÌB³Ñoç;Á[T˜‚; 'àƒÛ@…Í°	öÂ~¸æ!Ç š¡•ÿôÀ…m0=|¤•ã¬e3ø®åƒÍ¬^×k+ç<spáÒ)¬åeµKò0ç+Œ8 Ç`0ÆÙcH® Ùq˜ƒC°—óí†Ý0Gàè B2|lNr­¨0kìj2üIžkö.ï·À¹	nƒã|ó°×àœ„y˜ãzBN\û_¶ç#àÜ¨Ùpº¡ZàNþ“×j3á3ÝŒ#³ÌaØÌ¥' ÷†Q;…ùËQ0[¹ÆÇ@€m„!´A¬‡ØÁ
-5Pç¡Ú!1ˆÂv„ (Ð“0HÁ˜€ 4B5Ø JÁ^h…nXN¸vB=ôÂÐ!xZ tðC1TA|ÆÁ·À4Ì€F(ü-|„ð2¼ÿÃtÇ‘¹Öv—8|Û	tÆ0ú
-|sS2KÈGRŒäÿ2åhLá—Æú:êehÂ»PyJœŠ6ˆë‹œ&Ùl<ÜI·Ða¹¶ÉuX~ÍqÖvÖr¶ü¬ù¬	@†’¦,XÃ¯ñ¿ø-üàÓW±RÍÖ“‡¦’,ôPïg£ÙF¼¥ò šrfðÑbÑY bè¡=Ó…þ.¨üVº™Fäê•o‘äò¦WÈÒL|4K!zAš•!Šß…üÿØ®…Ô
-endstream
+<</Type/StructElem/S/LI/P 234 0 R/K[218 0 R 220 0 R]>>
 endobj
-
 222 0 obj
-<<
-  /Type /Font
-  /Subtype /Type0
-  /BaseFont /JHKRRL+iAWriterQuattroS-Italic
-  /Encoding /Identity-H
-  /DescendantFonts [223 0 R]
-  /ToUnicode 226 0 R
->>
+<</Type/StructElem/S/Lbl/P 225 0 R/K[26]/Pg 297 0 R>>
 endobj
-
 223 0 obj
-<<
-  /Type /Font
-  /Subtype /CIDFontType2
-  /BaseFont /JHKRRL+iAWriterQuattroS-Italic
-  /CIDSystemInfo <<
-    /Registry (Adobe)
-    /Ordering (Identity)
-    /Supplement 0
-  >>
-  /FontDescriptor 225 0 R
-  /DW 0
-  /CIDToGIDMap /Identity
-  /W [0 1 600 2 2 300 3 3 900 4 4 450 5 11 600 12 12 450 13 17 600 18 18 300 19 25 600 26 26 450 27 29 600 30 30 900 31 39 600 40 40 300 41 47 600]
->>
+<</Type/StructElem/S/Strong/P 224 0 R/K[27]/Pg 297 0 R>>
 endobj
-
 224 0 obj
-<<
-  /Length 13
-  /Filter /FlateDecode
->>
-stream
-xœûÿ  ¬»
-endstream
+<</Type/StructElem/S/LBody/P 225 0 R/K[223 0 R 28 29]/Pg 297 0 R>>
 endobj
-
 225 0 obj
-<<
-  /Type /FontDescriptor
-  /FontName /JHKRRL+iAWriterQuattroS-Italic
-  /Flags 131140
-  /FontBBox [-71 -212 847 780]
-  /ItalicAngle -9.5
-  /Ascent 780
-  /Descent -220
-  /CapHeight 698
-  /StemV 95.4
-  /CIDSet 224 0 R
-  /FontFile2 227 0 R
->>
+<</Type/StructElem/S/LI/P 234 0 R/K[222 0 R 224 0 R]>>
 endobj
-
 226 0 obj
-<<
-  /Length 1264
-  /Type /CMap
-  /WMode 0
->>
-stream
-%!PS-Adobe-3.0 Resource-CMap
-%%DocumentNeededResources: procset CIDInit
-%%IncludeResource: procset CIDInit
-%%BeginResource: CMap Custom
-%%Title: (Custom Adobe Identity 0)
-%%Version: 1
-%%EndComments
-/CIDInit /ProcSet findresource begin
-12 dict begin
-begincmap
-/CIDSystemInfo 3 dict dup begin
-    /Registry (Adobe) def
-    /Ordering (Identity) def
-    /Supplement 0 def
-end def
-/CMapName /Custom def
-/CMapVersion 1 def
-/CMapType 0 def
-/WMode 0 def
-1 begincodespacerange
-<0000> <FFFF>
-endcodespacerange
-47 beginbfchar
-<0001> <004C>
-<0002> <0069>
-<0003> <006D>
-<0004> <0074>
-<0005> <0065>
-<0006> <0064>
-<0007> <0020>
-<0008> <006F>
-<0009> <006E>
-<000A> <0073>
-<000B> <0070>
-<000C> <0072>
-<000D> <002E>
-<000E> <0054>
-<000F> <0068>
-<0010> <0075>
-<0011> <0079>
-<0012> <006C>
-<0013> <0067>
-<0014> <0061>
-<0015> <0076>
-<0016> <0062>
-<0017> <0031>
-<0018> <0030>
-<0019> <0043>
-<001A> <0066>
-<001B> <0063>
-<001C> <004E>
-<001D> <0047>
-<001E> <004D>
-<001F> <002D>
-<0020> <0046>
-<0021> <0028>
-<0022> <0029>
-<0023> <0052>
-<0024> <0045>
-<0025> <0035>
-<0026> <0033>
-<0027> <007A>
-<0028> <0049>
-<0029> <003A>
-<002A> <0038>
-<002B> <0036>
-<002C> <0039>
-<002D> <0053>
-<002E> <0078>
-<002F> <0050>
-endbfchar
-endcmap
-CMapName currentdict /CMap defineresource pop
-end
-end
-%%EndResource
-%%EOF
-endstream
+<</Type/StructElem/S/Lbl/P 229 0 R/K[30]/Pg 297 0 R>>
 endobj
-
 227 0 obj
-<<
-  /Length 7501
-  /Filter /FlateDecode
->>
+<</Type/StructElem/S/Strong/P 228 0 R/K[31]/Pg 297 0 R>>
+endobj
+228 0 obj
+<</Type/StructElem/S/LBody/P 229 0 R/K[227 0 R 32 33]/Pg 297 0 R>>
+endobj
+229 0 obj
+<</Type/StructElem/S/LI/P 234 0 R/K[226 0 R 228 0 R]>>
+endobj
+230 0 obj
+<</Type/StructElem/S/Lbl/P 233 0 R/K[34]/Pg 297 0 R>>
+endobj
+231 0 obj
+<</Type/StructElem/S/Strong/P 232 0 R/K[35]/Pg 297 0 R>>
+endobj
+232 0 obj
+<</Type/StructElem/S/LBody/P 233 0 R/K[231 0 R 36]/Pg 297 0 R>>
+endobj
+233 0 obj
+<</Type/StructElem/S/LI/P 234 0 R/K[230 0 R 232 0 R]>>
+endobj
+234 0 obj
+<</Type/StructElem/S/L/P 251 0 R/A[<</O/List/ListNumbering/Circle>>]/K[213 0 R 217 0 R 221 0 R 225 0 R 229 0 R 233 0 R]>>
+endobj
+235 0 obj
+<</Type/StructElem/S/Link/P 236 0 R/K[39<</Type/OBJR/Pg 297 0 R/Obj 254 0 R>>]/Pg 297 0 R>>
+endobj
+236 0 obj
+<</Type/StructElem/S/P/P 251 0 R/K[37 38 235 0 R 40]/Pg 297 0 R>>
+endobj
+237 0 obj
+<</Type/StructElem/S/Strong/P 238 0 R/K[0]/Pg 298 0 R>>
+endobj
+238 0 obj
+<</Type/StructElem/S/P/P 251 0 R/K[237 0 R 1 2 3]/Pg 298 0 R>>
+endobj
+239 0 obj
+<</Type/StructElem/S/H2/P 251 0 R/T(Why sponsor CNG Forum)/K[0]/Pg 299 0 R>>
+endobj
+240 0 obj
+<</Type/StructElem/S/P/P 251 0 R/K[1 2 3 4 5 6 7 8 9 10]/Pg 299 0 R>>
+endobj
+241 0 obj
+<</Type/StructElem/S/P/P 251 0 R/K[11 12 13]/Pg 299 0 R>>
+endobj
+242 0 obj
+<</Type/StructElem/S/H2/P 251 0 R/T(Get in touch)/K[14]/Pg 299 0 R>>
+endobj
+243 0 obj
+<</Type/StructElem/S/P/P 251 0 R/K[15 16]/Pg 299 0 R>>
+endobj
+244 0 obj
+<</Type/StructElem/S/Strong/P 246 0 R/K[17]/Pg 299 0 R>>
+endobj
+245 0 obj
+<</Type/StructElem/S/Link/P 246 0 R/K[19<</Type/OBJR/Pg 299 0 R/Obj 255 0 R>>]/Pg 299 0 R>>
+endobj
+246 0 obj
+<</Type/StructElem/S/P/P 251 0 R/K[244 0 R 18 245 0 R]/Pg 299 0 R>>
+endobj
+247 0 obj
+<</Type/StructElem/S/Em/P 248 0 R/K[20]/Pg 299 0 R>>
+endobj
+248 0 obj
+<</Type/StructElem/S/P/P 251 0 R/K[247 0 R]>>
+endobj
+249 0 obj
+<</Type/StructElem/S/Em/P 250 0 R/K[21 22 23]/Pg 299 0 R>>
+endobj
+250 0 obj
+<</Type/StructElem/S/P/P 251 0 R/K[249 0 R]>>
+endobj
+251 0 obj
+<</Type/StructElem/S/Document/P 19 0 R/K[29 0 R 30 0 R 34 0 R 35 0 R 36 0 R 37 0 R 38 0 R 40 0 R 53 0 R 54 0 R 55 0 R 56 0 R 58 0 R 59 0 R 84 0 R 85 0 R 87 0 R 88 0 R 89 0 R 91 0 R 92 0 R 114 0 R 115 0 R 117 0 R 118 0 R 137 0 R 138 0 R 140 0 R 141 0 R 157 0 R 159 0 R 160 0 R 161 0 R 163 0 R 164 0 R 165 0 R 167 0 R 168 0 R 184 0 R 185 0 R 187 0 R 188 0 R 204 0 R 205 0 R 207 0 R 209 0 R 234 0 R 236 0 R 238 0 R 239 0 R 240 0 R 241 0 R 242 0 R 243 0 R 246 0 R 248 0 R 250 0 R]>>
+endobj
+252 0 obj
+<</Type/Annot/Subtype/Link/Rect[311.4 441.1695 466.2 460.9455]/Border[0 0 0]/A<</Type/Action/S/URI/URI(https://2026.cloudnativegeo.org)>>/F 4/StructParent 0/Contents(https://2026.cloudnativegeo.org)>>
+endobj
+253 0 obj
+<</Type/Annot/Subtype/Link/Rect[124.2 288.524 376.2 308.3]/Border[0 0 0]/A<</Type/Action/S/URI/URI(../CNG NYC/Sponsorship Prospectus.md)>>/F 4/StructParent 5/Contents(../CNG NYC/Sponsorship Prospectus.md)>>
+endobj
+254 0 obj
+<</Type/Annot/Subtype/Link/Rect[72 112.93201 230.4 132.70801]/Border[0 0 0]/A<</Type/Action/S/URI/URI(mailto:hello\\@cloudnativegeo.org)>>/F 4/StructParent 8/Contents(Email hello\\@cloudnativegeo.org)>>
+endobj
+255 0 obj
+<</Type/Annot/Subtype/Link/Rect[270 275.164 450 294.94]/Border[0 0 0]/A<</Type/Action/S/URI/URI(mailto:michelle\\@cloudnativegeo.org)>>/F 4/StructParent 11/Contents(Email michelle\\@cloudnativegeo.org)>>
+endobj
+256 0 obj
+[/ICCBased 318 0 R]
+endobj
+257 0 obj
+[292 0 R/XYZ 72 712 0]
+endobj
+258 0 obj
+[292 0 R/XYZ 72 570.336 0]
+endobj
+259 0 obj
+[293 0 R/XYZ 72 602.112 0]
+endobj
+260 0 obj
+[293 0 R/XYZ 72 217.99799 0]
+endobj
+261 0 obj
+[294 0 R/XYZ 72 712 0]
+endobj
+262 0 obj
+[294 0 R/XYZ 72 371.638 0]
+endobj
+263 0 obj
+[293 0 R/XYZ 72 712 0]
+endobj
+264 0 obj
+[295 0 R/XYZ 72 667.624 0]
+endobj
+265 0 obj
+[295 0 R/XYZ 72 222.26398 0]
+endobj
+266 0 obj
+[296 0 R/XYZ 72 712 0]
+endobj
+267 0 obj
+[296 0 R/XYZ 72 399.814 0]
+endobj
+268 0 obj
+[295 0 R/XYZ 72 268.224 0]
+endobj
+269 0 obj
+[297 0 R/XYZ 72 667.624 0]
+endobj
+270 0 obj
+[299 0 R/XYZ 72 712 0]
+endobj
+271 0 obj
+[299 0 R/XYZ 72 384.552 0]
+endobj
+272 0 obj
+[291 0 R/XYZ 72 568.1335 0]
+endobj
+273 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 256 0 R>>/Font<</f0 282 0 R>>>>
+endobj
+274 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 256 0 R>>/Font<</f0 282 0 R/f1 285 0 R>>>>
+endobj
+275 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 256 0 R>>/Font<</f0 282 0 R/f1 285 0 R/f2 288 0 R>>>>
+endobj
+276 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 256 0 R>>/Font<</f0 282 0 R/f1 288 0 R/f2 285 0 R>>>>
+endobj
+277 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 256 0 R>>/Font<</f0 285 0 R/f1 282 0 R/f2 288 0 R>>>>
+endobj
+278 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 256 0 R>>/Font<</f0 282 0 R/f1 288 0 R/f2 285 0 R>>>>
+endobj
+279 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 256 0 R>>/Font<</f0 285 0 R/f1 282 0 R>>>>
+endobj
+280 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 256 0 R>>/Font<</f0 282 0 R/f1 285 0 R>>>>
+endobj
+281 0 obj
+<</ProcSet[/PDF/Text/ImageC/ImageB]/ColorSpace<</c0 256 0 R>>/Font<</f0 282 0 R/f1 285 0 R/f2 288 0 R>>>>
+endobj
+282 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/SVSSGG+iAWriterQuattroS-Bold/Encoding/Identity-H/DescendantFonts[283 0 R]/ToUnicode 301 0 R>>
+endobj
+283 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/SVSSGG+iAWriterQuattroS-Bold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 284 0 R/DW 0/CIDToGIDMap/Identity/W[0 3 600 4 4 450 5 6 600 7 7 450 8 8 600 9 9 900 10 17 600 18 18 300 19 21 600 22 22 450 23 27 600 28 28 900 29 33 600 34 34 300 35 54 600 55 55 900 56 58 600 59 59 900 60 61 600 62 62 450 63 63 600]>>
+endobj
+284 0 obj
+<</Type/FontDescriptor/FontName/SVSSGG+iAWriterQuattroS-Bold/Flags 131076/FontBBox[-8 -212 908 811]/ItalicAngle 0/Ascent 780/Descent -220/CapHeight 698/StemV 168.6/CIDSet 300 0 R/FontFile2 302 0 R>>
+endobj
+285 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/PDCCRD+iAWriterQuattroS-Regular/Encoding/Identity-H/DescendantFonts[286 0 R]/ToUnicode 304 0 R>>
+endobj
+286 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/PDCCRD+iAWriterQuattroS-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 287 0 R/DW 0/CIDToGIDMap/Identity/W[0 3 600 4 4 450 5 5 600 6 6 300 7 12 600 13 13 450 14 14 300 15 19 600 20 20 450 21 21 900 22 24 600 25 25 450 26 26 900 27 48 600 49 50 900 51 62 600 63 63 300 64 69 600 70 70 300 71 72 600 73 73 900 74 77 600]>>
+endobj
+287 0 obj
+<</Type/FontDescriptor/FontName/PDCCRD+iAWriterQuattroS-Regular/Flags 131076/FontBBox[-38 -212 876 811]/ItalicAngle 0/Ascent 780/Descent -220/CapHeight 698/StemV 95.4/CIDSet 303 0 R/FontFile2 305 0 R>>
+endobj
+288 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/TTRQOR+iAWriterQuattroS-Italic/Encoding/Identity-H/DescendantFonts[289 0 R]/ToUnicode 307 0 R>>
+endobj
+289 0 obj
+<</Type/Font/Subtype/CIDFontType2/BaseFont/TTRQOR+iAWriterQuattroS-Italic/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>/FontDescriptor 290 0 R/DW 0/CIDToGIDMap/Identity/W[0 1 600 2 2 300 3 3 900 4 4 450 5 11 600 12 12 450 13 18 600 19 19 300 20 20 600 21 21 450 22 27 600 28 28 900 29 32 600 33 33 900 34 45 600 46 46 300 47 51 600]>>
+endobj
+290 0 obj
+<</Type/FontDescriptor/FontName/TTRQOR+iAWriterQuattroS-Italic/Flags 131140/FontBBox[-71 -212 944 780]/ItalicAngle -9.5/Ascent 780/Descent -220/CapHeight 698/StemV 95.4/CIDSet 306 0 R/FontFile2 308 0 R>>
+endobj
+291 0 obj
+<</Type/Page/Resources 273 0 R/MediaBox[0 0 612 792]/StructParents 1/Tabs/S/Parent 1 0 R/Contents 309 0 R/Annots[252 0 R]>>
+endobj
+292 0 obj
+<</Type/Page/Resources 274 0 R/MediaBox[0 0 612 792]/StructParents 2/Parent 1 0 R/Contents 310 0 R>>
+endobj
+293 0 obj
+<</Type/Page/Resources 275 0 R/MediaBox[0 0 612 792]/StructParents 3/Parent 1 0 R/Contents 311 0 R>>
+endobj
+294 0 obj
+<</Type/Page/Resources 276 0 R/MediaBox[0 0 612 792]/StructParents 4/Parent 1 0 R/Contents 312 0 R>>
+endobj
+295 0 obj
+<</Type/Page/Resources 277 0 R/MediaBox[0 0 612 792]/StructParents 6/Tabs/S/Parent 1 0 R/Contents 313 0 R/Annots[253 0 R]>>
+endobj
+296 0 obj
+<</Type/Page/Resources 278 0 R/MediaBox[0 0 612 792]/StructParents 7/Parent 1 0 R/Contents 314 0 R>>
+endobj
+297 0 obj
+<</Type/Page/Resources 279 0 R/MediaBox[0 0 612 792]/StructParents 9/Tabs/S/Parent 1 0 R/Contents 315 0 R/Annots[254 0 R]>>
+endobj
+298 0 obj
+<</Type/Page/Resources 280 0 R/MediaBox[0 0 612 792]/StructParents 10/Parent 1 0 R/Contents 316 0 R>>
+endobj
+299 0 obj
+<</Type/Page/Resources 281 0 R/MediaBox[0 0 612 792]/StructParents 12/Tabs/S/Parent 1 0 R/Contents 317 0 R/Annots[255 0 R]>>
+endobj
+300 0 obj
+<</Length 13/Filter/FlateDecode>>
 stream
-xœ­{yp[Ç™ç¯û] ’ qx<ðà^ 	Þðo²,<$ÑÖmÉ’¯±Û‰Â›IæÊáÌ?If23É6¤Ä‘5³ë”w×å©¤²5;öL¦’Ífk½»©ÝÍÎVE›df,r«ß(R‡íL­P|ý½î¯¿þú»» (ÆUh_yò¢ZzH{À_ øæñs'N¹Ç÷6@N¥Þ§ž:~óøÿ¡@ÙK@Í;¹–]uõ$ÿˆœÐsòäZÖvN~ˆ|@ÃÉÓ¯œ¯pü%yÀ[§Î®dÿíð_\Z?àøéì•sÂÇœ—Ö_PÏdO¯¥ž\}h«èÿ>wö‰‹ÒcÝtÚ |ôÜ…µss¯=:ùüÿŒßüßæBŠÞ¨lõÒ7·nSçÖí-•Ö‡Š[·ùH =ôMò(ÿÛ5÷]jßžýn~þ^ìE7ºÉy€\ÞúÇÂ;½E&éwI
-`ÐU†ÆhZU§o¢tašÉK‡ÖågMéÌquã€Áh0ûš6¬¬hËþ@€!ÍÔR×AÌ$"ŒèLÍ0ªk-a‚®®Þ<^$’ÌT3™DŽz’‰\PH2šÜEeÑd2»ÊÄù+×)¥ÉL‚Öª¼÷z©—$ªUF“Zâº›¸“™„Æ0o¬¥¯ûÇŒ0QgB˜y“_ù’É<‚_]UÙwç™:|½‰”$GWF™<j˜L/>b´€ÃPÙü¼`ñ´_e½êM§Õœ…]eMóF ÿ¦²v>ÞÎ1¿;o¨ÇÕ¬ÊìóFÆ¯2•Ù9ÔÃ¡žŒ?“N§ýŒ™#¹Â°h0Lsä s$ýÓ¬–CµÓÙ›N¬pŒ›–ÓéÕlš‘p:ßAZ]e¾¤–HG˜¤«£*ƒÙU•)Éyƒ)Z‚Ù´„?H3’‰0Ù7ÂêjNYN¨|o×o±ÏŸLÎŒ®0©% 2[RÝP7	çÚ¥ CFfÞŸ]LZ:VY|É`$ìçrÉ³aŠÎŠ’áë –šm:+ÒšÊ %²Œ.gd…‘SZ"¬HW9·¥É•›"–UNÅ3iŽ’I™ÜÚõëE¥HŽ&ZÛ†S¬ï6$‡E…„5†$ƒutCËr¥šÂ†Ÿ+„©~ß‚Z6e-Qòé¬aÞà“ãšTÊí_KÜ(q@7~-n	DX™ž£t”­fSæÔÉ¨*+KNq*+Óiæäo‹†Êœ¦¾\ºÊœ¦PÔ›"V6´,s%3êFFe.-¡EX¹>½ßÈ‰«©t+YÓ®D˜[Ÿ^0¦—¬N ÝÀÜf¿GÏ¡<yÀÈ•—'É&˜+Ì]ŽÑ`"WÆNL0âÓT&çƒ‰•/ël	hŒd°ßçShÐìI³²ä8s&Ç3ŒîVÖCT˜ÜZŠ‘$ÃðuBˆ©-¯Žèè~ƒ•k	u”•j	V¢19“P™GK¨F²ß©¬$pÁD"Á%áIføXÎc³O„ýõéóé9xÃV¡ço+õåm•žx»GÏ‰¼õë9‰·ÕzNæmžSx[«çl¼­ÓsE¼ëZALÎLï74µ•‘G¹ÛD˜¾cÐ·=xÞŒìm^°U¬,ü°ó½~ÛÚ+ßèÎýôÔp„Õë9Â[MÏQÞ6è9·A='ò6¤ç$Þ6ê9™·MzNám³ž³ñ¶EÏñ¶UWMËmÓÕ«Ì¨I‘7Ž,÷ÆVn¼í:k³¶–ëÐUu\}ˆZµl¯Æ#üûbøùî;ºÎ•Ê£ÜôXGKN"ÞQ£=mî2ºC<ÃéÒÕn“ónyœÑû×d$ü@^x?|ß2SfjXëÍu/ßk®ªãáŸ!™í°˜ÞZ1a½„ÊHr¥7Âúô…/¨¶ªã<60œÜØ×Æµ¬j,ûyøÕ×{	ñzZ"¬_gð±
--ÁÄ ƒ&ZÎ+N†×6Z5UÜè°Ýhj«EÉZ¢€­².ñã†¨Jªÿ†’ö¤<äÚ“ê†fÎÐÆ2LNÞë·ö¬ô$&3«“’ÙÕyƒ‰É¬ŸIÉy÷ÎÉjªÊÄ6–íõkÌžã©Ëž4WÉ¨ZD³‚«œÌpeHÁ,“î£ÊÄg"È™‚™Õ|H½»V:Â²PU•I¡¼,´ÁÞÚbvs|Lç‹r-o‹oÆ’4Ã~£UÔfâÍwªœ¯¼*˜dRprgc)ñAÖž×–ÆM~ïN’uex¥sï–*ŽëšÚÊ¥8Æ*’Æ¼1m¨ƒéÖ\;ñ„#ld×è¢~×hâsßoFRgýá÷[0¥³ð†ªrÛè}8*““­¬=a£æ–¹}†,Ég™CKX[çª©ƒj«Ö›§?¦çìb0Q˜òšôøÿ/+æ{âqlPëõvØK çs\Ï¡?\Ê„žÃ@8ÀuÆÍïf[“:ƒ×rûëàîne=-6õþi=âq³XK„íÓY_K„Íp)Žjj«:¶¡eÒšÕ¹A³™p„Íé×±p„Íë×A8° _'fÏ¢~˜=Kg<aû9pä88¤ß G˜¡ßà5T8ÂÒúbõÖo«ïŽG8t„ã™Ð£Ï„Žr<:Æ×GX†¯É,_“Ë|M¬pœ‰p„­r¬qç88aò•
-GØI“/­›|qè1“/=nòÅ¡S&_:mòÅ¡3&_:«ç0¸­Àsæ‹‡#ì¼Ž„#ìºù–GØzŽäq.Z Ç¹dâ<Î“zCÛT/›oæŒ+Èg<eýi=GòÏX GxÖ9ÂszÃÛô~Ë|3ÑŸ·@Ž~Õ9úzŽä>báEä/é9ìÝ¦÷²ùf¢Ô9úÇ,£_Ós$ðqäÈ>¡_/6K\&û¯‹T5´€?N'ÂÌ¶Æ„†ù+…dá)–Bh¯à€ Íñï@OˆD D8$A Ç@2'Š¢"*å.§$W…ÝW è
-¸TZyçgäÇ›ÁñÞíAú;wN³ ù½	uñj 3 „fBé  Ar¹D{e8êŽ
-eöÒÂI2í ·î|z[[ H9}õè0ylÿmNu:¨]øz¼¸ˆRAª"¢@÷™Ç¯ø…H²”P`x‚ ³ÉTÅYÿ4sÌñZðŽF²”Ý}Xž óA$ÒétÜámð6¼Ág‘½.ìŽ*Ñžžh§¯Âj¼E‰*Z}¨»+ëéî
-iõŠ,+‚æîéî*À_›ñJþéX÷,ï™í‹'”ÎÉ’‰:Mh—CÍ­ÍšÜ?—':šö„äþ*ˆöô÷N¥TíŸR5Õ¶²¿¯­jii®˜¨ßü)®­^lÚ3¡nþ\†#[·Éô|èŒ·•»œe¢²”Ìˆ ÇBÈðŒL$)!qMùàu¹\.¯b÷‡}œk·‹Æ¢|BE¬B‘eí+Âà3ÅÏT/Ô}£øqÏóe³ÉG¨¡ÂIŽ$_}5¹ùÇ|§½KãšœÜºM=Ô‰JÔc(ÞïõPJÈ>ˆ T$ë–èyT™¥BV&‚f«ª€ªúª@M5*QÑà	ÚìU&3y‘ÊŠìõø¢=±
-YÖ¨¬(=¦h¯¯O¾°8›ýâ$±©ž}‘Xäüœ´\LþäJG·ãì™#Ÿ]˜LŒed{I|:º·~j’üè¨a—ö¶Õ‡-ÏèÝºM'é»p#„o|»”H"ÉÛZ5(š(’,h¦¸@ÁÚÔ{p ƒyDð<HëƒÉp›+õx<!O°Ùå	j\QAM–MË›ž;*h¡XOÁâdÅùœ ™]ê8s oÖ)tÏ>;;m-vÓDÏ„ápˆ½ÝO'RÇ—g^y¬«“ôß©îë‹&/”ÊáÎCÓ•Þ8(â[·i%u¢uÐãÍ 4¯?‰Ž¬HIÙÒR ´®´¶Â‹8‚²½b—úd­ç>Þþøäø3û–OŽ?»o:]b—ƒãVã¸¼’ùÜÜ“«™ÏÍ¥ŒÙÁZo|o¾1í{  
-u¢
-×¾-*4æ†  Kw_I¤fÊ+ªÂôipvM	ïö<læC'qm” ¨BUÐÛà’í{xˆËÇ ¯'ïè¦×+ÂÀÁYX»402-wÍF¥px¨½ÃÞNÅ§GFçÆTmó-ÒQ[ÕÖÕÛ?¸ù_@Ð¾u›z©Mh‡+|AMß-˜ dyÀNÜs›Ð%ÓUc>îÝ]¡ÆÆ—<7%Äåíõø**j©×#koœ«ï¯[èKÍ56Lî.“ÈÖÆ\ã‰±æÆÉÈ°þüIGg[kc¨»5P+ÛûFæ4‡Ú«:ÂõÕ²Cñu·Í?ÊýÆ½ÕKUê4ýæ›¯:)Ýé8¢X&7bš¥	.Ç¸p×qLÑîrˆ{ñ<HëƒÉìpœ&O°ÁÉg‡ªLjÔÛ¶©Œó³ž]žÓ1K¦,‡ËûïºÎæOÉ{LÁL[íÈÛT„ñ–2qÌÚWä ©H'œWdÁ”x‘¹õœ­jŒ±Ù#2PÙaPq#9>[åïÚü_ãu€Â‹P÷ñŒ…c y†† Á%Ø+ÂAE‹‘C¾ø^|ñE>ç@?NoAA ^+
-”zÌÌÛ3(.—É4·(äsë‹ëÿÃACzáÎ§é…‰	ìðÇwQÅ÷HM‡0´ÃsD«(ð½NÉTð`oÑ¾3Û¿·ÌÒw7¿ö`YÚºMë¨ˆ*\¶¬¯ÜJn\ÈËâ®`íËˆâ 5¼+D?hÞÃ¦¤Óéï¸<A¯&íŒÃ1wT°rT¬‡ÃùØÊÁYÓóõ¤wóßçwBjî¼ÿ–nîECo¼ÛFÊëB÷qéYqh„rIYnêcföÖPï	zCfRð5ÆÌ{S²¬íïë	§'—J<BíÒàÈ>¹s¶CÒMî"³Ý/¬½=ÞÕ3½drYÙDôÍÕTX\–ÞyïÌqKßø5}%\ß6b&wB†L	ãIm³»"£„”ˆv_8Z`Åë‰F•ê„Ó3gJ‡JêkŠÊè§îœ)PÔméT£NÔ wølT–ò"°t[îÞ¼ÂLÍØˆ,›ÖeÊCÌ*DÇ¶ËÀaxÆDÇûc{>$ÝK’Gom-PÛ^ÛÖBª=ÁVdßs¿rò™;fª¥üþÜmpMM,•zÅ:cdn©óÌDe¦–Ö£­ÅNšèO;Š¤XWÚÔþg©µcS¿¼«ó0×©í‹&–y,:8ÕS[:<r·æÑò±›½ZFvÄî*3–ZU¯U¨ÉÝéD˜¶¸#âòZe»¦»ëOïCéCáRôx< ÜµÕpÃí	6ð’0ð é=¨ìy~wô.›=ø¹‡•=‡ï¼w_ÕÃãZbë×´†ÚQH¼ÅF¥„Ûb¡Sü¨sŒÌ0W~Â˜¨ð¶òó*†iwWc¬a¬Šš(©’ùÕÓ£øH¨Qì:SLÅÍþ¢â£31ßÞÅ¹õP}I%9’´ôÔ½u›ªùÚô¾kØ{g(±]óðäøÀªÒÊÛÅÏûÓú`2Î±Â=9VÑîÏ±¹Ùþ{´DÓ;rìHüwÕ·+Åêüà‚€Ñ[(æg[YXi`†@ÈÜÍ²Å(vy­,‹º5¥1¢J‹ã­c¶ï5¿óâúkŽ	Úõ•îoð#ª€á­Û´Ÿ¾‰bøÑŒT|$Xkª ¢H‚(­*á‘Å¬„e«®®v8€êæê&-àð;öxÊQ{C¯ˆ-³ÝYl6ÚÃí$Ÿem¸oã‰7û6ž8p¼Ü­<7g>~±h¨Æ/Ú†?_ÿÉ—ùßÄÓg.´4ýžõüï—X5æ	}ë6£o¢š×’U•E61ªóL›Ç¯»µd5üÁ³–,8—U=*»Ž^³½Ÿºh.™rôô-®º¶ÄXßxx$|>íxoù‡_:œªìêæ\¦½izÿð¾€‘ÙzmK'ÿ“¾?bñ.I™GÁ¬8†f$óLÊOüÔ-Ëc2çÆ=®ò€æª°Ù«yqÛ«°Ž¥ùÒÈ<bó¸92Üïì>]¾|¡øByQ²÷™âË¡¢òß-þÝGm­-owŽºÛ/Št:ùxw<ÙùxòÎÛmý¦ÍLoÝ¦EÔ‰Z.ÿ{Ñ.Ù¤î•M-jƒù:û!Â±¤ÃÖÆŸšš1Ê’e}‰¥R»”ê÷·6öFOÏòSÍgçS½{Z.Ö–ÇG\±žÀ'OÐÐyÓ†kâ{dÂ-˜ÇÎ™|>u¹]å¢}OØ­	š;Ê?‚öŸ”µ}—.¿l>éá;_£·î|¾3fÅ.Ëv5\µ¬”J´9j!A$ñDáL1Â=YyW­Tÿ ,Y´PwÅù¢÷aHñbw¹Ü¡ ?ÚÖÜ{´Ý!h+}ÆxqõU)0=œ~¤ï“k\Zq;å§SiGÑg‹Ò·ïxlàê³‹|ö\¦!òGG'z›lÊû  ÌÑ[(ã·WE$q/—8!?!p‘“¨ ¹éÝüþ‰°tiþ“ëWâ:ÿÉùËtjói»xç;ôÖæËä™;ctŠ¯ñ
-QÈ_’4ÔÆýà¶uˆ¯}Œ2·£8wÇÊ+¥¤¶”(‹‹VLkèazEæ}… Ráò¥ýÀŒDÌ»( E(âw7Ö!4 ˜¡íyÕ±ù¥&2îØ|­›ÞšøùÄæ¿1éþ`ëIš ¿†¡iV9oÄ‹A@>Êc<WVÇy„<™þV•›Ú+Ãå==±¨œ7ó
--êþÁüKÓÿ’§T>0:3²@Æßù“ÎÉw®h­~s öççÌuš·ž$¯ì^åu"1×! /Ø^²¬l_4F}>/yåž…ï[ˆšrš ·P‚*žfóFÜ¯ð[
-‰®C–ùÅæ]¥šµ‡$Šô‚B$ˆàfy/N:î,+­ô•V•U¹\ž€Óf÷‡£š;Å0ÖYHešðÂâ¥8pðìÊóéËnv¥l²mýz˜Þ2ö|JÙü$<mo(÷6·lnôjùy[\¿_¯EéO®ƒR!_ñ<¥nkW	(m—ÈŸ96¿ÖDæ›¹frÄAoMü¯‰_æÏcüa€ÞB=¢ñvµÎå¤’ÀÓ(qŽA’¸’¸'68e{u˜îIÝÖµÂv}ÕèÐ¶ÍïÈõ£Öö>shz½zlO¼üp±˜ˆG†Õ”Až¦Olþ"\^¿2™Š¶¶µN§*=½Cµ5EäªÅcåÖm¢o"Âój±‚xˆµŽŠ’°ÇI„Äc28Â#da†c½¥¡¾Æ_VR¤ B"ŠÝ&Û*Û†Šï{Ðb$8~À.weã±æÇfŒuc–ÄFGž^0²µ©ŠÔÈÄ!»˜L.9ÈoÇ|öæöÃmÝCSÉµr±h6>tb8ÙÛÒÚ>2¼§¸«×ŒµÑ­_Ò6êD?;}
-¥¤®¶¦ÚOeÐÂÉÅ³vÄUbå•ÔŒ,QË&­[·"ŠÃü.ÝÜï.4ÏSªü0”âÚC0øá¿p/œ6ë: A4xµò7B±±Qá7	Ö­’–¿dªˆÅ¢
-‘b±
-.q¼0tC²Ï“ã35Ýñ…éæCÞ³ùl×õ9÷ôDìžA11K&k«FzûQ5‡¸wßæÍâkž¦½ÍZÔ²“@xmgÞm˜.Âƒô Ùy·Á“aâÒâ%zëÎÿfß‡|žºP€((A‚|E9Bn’O³î0ŸÙœÏ~„1ÀmÐ#SQ û"@”qGmg3¿	È×vº^]èzWgu¸º¥¡žW*ºYÛñ„‹™Wo÷š`ù]ÿ1Ë…{ßïô‘EÒÚ9pqîèñ¹qÒ70ò¼qmÉ&Ä’æÓsÄ.M&gÌ§ãèìÔ)ŸÍ9ÞÑõhßâÄÐZ…Í9=2¸:@^Š–—E:¬çæ×“ƒµ%Ñ˜õä±rhë6­ ·àE=ñ¨ðƒ@‰À£ÂÀŒLD‘f%«ô÷ù _Ð×P[/<!Ÿb¯ÌW?fB¨Øu³»k7_=¹üg®}¾CjH,­$kiéQ‡˜Ø;n>çW×ÞøBû¡?¼HÛº—÷=596;Qéì²žÖÙ‡ßOuÐ7M^Ûâºbò*‘1²^\#ùë*Ÿ3Ú¹y,¤’ÆU„W¾‡IÚ±üg¯}¾S
-“GOþël’OîfòüêWw±IPµu›ŽÓ7ÑÌkÈÊŠ{îjMÞvÖÍh
-ê»«½÷²6o77žV‡Æðb&:0½8³÷ÂÔóµƒµûû÷ŠõOîŸyjÞ‘èëˆvÎ%õ®—{*~´so—®GÆ‡Z;K\žý‰Ä¿‚„²u›.P'F0êî
-U{Ü’ÙWN„(6oëòßwñûY¢¢˜0kŒÄõæÞ¼ýýP¬PóšPyQÞéóz6¡(yQ[›±¾Bª…º¹Jz;¤IÑSÞ«*Ee_®K4'k:kÏÂPçö€Í^ö;ÎhjO°ÁÆGƒurÝžvôcý5Sn%ÛÖQ88SJŽTµÂPí„G9ÙÖã}äÈÁõ>„ãMÀï'OðkåB%•ÿ¾Òç))†ö†€l}gi·¦	n³è´RGOöWN³Îá?‹X¹ž§úsÏmþ-9ßÝj&z·ˆD#/Ð·! 1'¯¦âÕ¼è9T¸ž%ØY æd¤«/”?VNß~ì±Â½*~JEpÇÖM·ú\N^0ñÀgæ*ÞyÏúõ1ÿ­5žù»¿Á±²ÁÿEøïþÇg~ÈÛŽù«­¡-E¼&…ÂqóD²ùs@d[C›ß¯	?Ãíú]s'5 R³DÇ€ð†É¡&©^j Ô@œ Ú©7y}ÔÀëÔÀ¡|ÿ5àçó©ºü¼5ÐM´PÃ&ý7¶^£¦©F>.¼„ÔÀ+Ô@5ðj 9·å×ª¤¢D7i½žÊ¯[E(.‘øÚ Z0…ø‰‘OÑ:ZGOÐw„fá_	/‰mâiñ¯¥FiIVä/Ê?RÎ*_TþÉ¶×öqÛ_Ùþ¡èãE^ôwvÉÞg?mÿwö_OÿKÇ£ŽËŽ—%é’?-%¥Ï•¾Vú£Ò_äuÑ‰ï¡CÅ·HŸÈÏJ½ šµÝ·F±ÀL[à0A_ÈÃ|7HáûyXDqæa	{H*Ëh%Gó°óä“y¸ÇÉóp1êi";L8‰³8‡§pë8“¸hGbP1‰f šXp­P‘Å¬šcgpÜì?,.bgq*Fp+8‰u\ÄVpOä±WÌù#8…SPw¬ÈÇ/`O`ð$Ö°ŠV¬c*™xœÒ¨XÀ%s­‹¸€³P±„I\D§°Žt¢íæg 0C˜Å€Ig'•Ý4–ÙEãÃ­ªîšsÐÄ{b[wùøÍÖNà,N™²1)­"‹§ "ôÏ”öÖñ8ÖL¬e,cgð8t¨˜G—L-<iêSÅj~¯û5{,¬u¬mK¡€¹ˆ³xÂäâÖpÆÔàEœC?ÚÐ†Ëæ‡k/‹Vœ1ç›qië—W±õY>ðNðoËÚ°ó8„	ŒCÀ"pK8 b˜†#˜ÃRHcóVtcè@ÚáD3Šá@7šP	…ŽøQ…jôàDñcü-€é›xkÑÈòé4#Ö¯Ïå $¾¤º#2Zø[¼tAœûlb³èWd{¾ó ¡#r7ÐzÉì,I¼î¹Z~µôªãªýªÈ(nÉÁxñÞû •k ×¿fð÷ÕT®‰¿ß´Áê@*íÏ5ò®[¶« büÚÊþÂ€UŽ/Ñi: Gi˜ÖHriËM²õ2?•£HÝVe¤R þ2Ca
+xœûÿ  ,¹
 endstream
 endobj
-
-228 0 obj
-[/ICCBased 229 0 R]
+301 0 obj
+<</Length 624/Type/CMap/Filter/FlateDecode/WMode 0>>
+stream
+xœm”Ëoâ0‡ïù+f‘è¡KlçÑ"„Ä£‘8ô¡Ríž!ØHàDyøïWöoh«Õ }öxf>;þñ¶»_ÚæÀ÷ægBïÜ7cWñýúyßFq¼iªñÂnxa¶lo³ýŒÚ®©zh½Ýl]=Dq¼uÕy´|‹ù_ÈŠOµû
+ð5h=öCs‰âø£Î<£	(ôD[Ën¨‡+%wQÿâ®¯7#Åñ“³ëæâ›ë£©Ô é[×T;èX;ÛI%:øº‘Òdëj
+ßÕeß†Å»k?ðeëŽDÙ±•H"¢é;Ÿê~è®4	Ý‘å#f^;Ë]íN4¹5ûmr7¶í™}“”„Qv6üN½üËþÂ4áÏQ±$õ5ôqmYL?7ö
+-Vå¾ÝWÜíÝ‰£y’$É‚æeY–_ñŸùÜ`ÙáXýÙw!\-hž$©YÒ ' 4N@ærP(/AE Bƒ@è‘Ð2‘ÈH*¬ARa(“>ŸS"KäD×Êo@’ˆTðË@ðËAðËEÁ/GŸ
+~¹d_‘‚¼ŸöËÁÏHNø¥Ø	¿~
+~Å¿»«à—Køi‰„_†Î4ür‚Ÿ†»?¬Óð+°ƒZüPOËùIøiœŠÆùiì™†Ÿ†Ÿ†ŸY‚à—¢k-~)ç'àg$~Fz_
+?¿Yü2¬3ðÓBð3²NþŸ°5â‡0ðKadà—¡º_Š32ð+$~lüRì’ŸÆI9¿~¹ô"ç§Ã•”»ç/§ƒ>_ƒjì:vCx‚ÂÕ÷÷¼vüù–µMëW…Oxoï©§×ò/6r÷
+endstream
 endobj
-
-229 0 obj
-<<
-  /Length 314
-  /N 3
-  /Range [0 1 0 1 0 1]
-  /Filter /FlateDecode
->>
+302 0 obj
+<</Length 8130/Filter/FlateDecode>>
+stream
+xœ­{	pÇ™î×=ƒ^ ¤ R €‚")
+xHâ!J”,@V$@¤®X—%Y‡µ’G¶dÚqì„k'/[9ü¼9¼‰Ó ”Xf;ÞZmœÍnò¶\Éf_œröi³NvS•z«MòRøª{ Š:œÍÖ{@aúŸîºÿþïþ‡PŠóÐ6uâ¸êØ~À×üÝž#{~²«ú-€<T¸ö8½çÇç’C@å‹@ý©}»³Óõ?üç> ¼@×¾}»³Ê¿Ñ/áÍ |û?õñÇlOáS ±8<•-ûžih=àñƒÙSG¤çmm ê¡ìÁÝ	L] Úš úî‘ÃÇŽ[’æa bðÙ#Gw™ùŸßH‘« ~Šÿúçãø8á¨,tÓk7¨máÆB÷mc×iùâè¯h­ `côå¿;ðoÍv]Ì§£=8?Vb%6c9y '~wg?'ëèë$	0è*Ã–Ô`ZUG®¢bãS&·¥X§‡5¥3{Ô™-)FýÙW-°`jJÛåñzÒIm`ÉL"ÄˆÎÔÌž£ºæÕ¼!&éêôeÉéB"ÉI5“Iä¨3™Èù¥$£ÉÍ§TV¦1šLf§™<qjŽRšÌ$˜w÷r/ï«p‘Är•Ñ¤–˜sG2“Ð&R»ÓsÕ„c†˜¬3)È\É_U'“:­²×'˜Ø6×DÊ“ƒSƒLLy™äOoº?åÕ¼ž™”Ê&&R^O{TÖÍ¡îtZÍØÙiÖ4‘òîTÖÆÇÛ8æë)u:3“U™u"•ñ¨LåcVuq¨+ãÉ¤Ói£~V–œbØ”báÈ^V–ôŒ°zÕd¯Ú0Å1®š°+žÎ¦	¦Ó…¤ÕiVÔé3éê ÊdvZeæäDŠ™µ³h	×›f$bŠ`7“‚êtÎ¼+¡òA¾]A>¿2%38ÅL-^•Y’êŒ:ÃH0×fò39°1•™ðd7¥SZÚ›VY|2ÅHÐÃùR %ÄÌ:+Iç@1[tV¢%4•AKdÝµ‡‘)F2ÌÜb%ºÊ©­HN]•±Kå3°x&ÍQ2‚Z«>WRä`¢Å»¨8¥úíŠTfÌB‚C’ÉþŒ:8£e¹P³ááaª‡ÅÆ$¿–0–(Ç™o"ÅŽßë¡
+®ÿZâry¤Á‰”×£yÓ-Þ«Ôs”²éì@ˆÙtF2ªÊ*“ëù*«Ôifãw›R*³	yÙu•ÙSÔ«2¦f´,³'3êLFev-¡…X•>²9•“§Ò>V¾[;b}dcjdÒèôxÓ>æýN=‡ªä–T®ª*ÉH6ÁìAnrŒú¹J~±Q‚‘jMe’"•ãìc²?13£òem-^‘löãüê=iV™f¶äp†ÑÛ…õ"Ìm€‘$Cÿ!DHË¥#:¸9Åª´„:È*´+×˜’I¨Ì©%Ô#ÙWjjìp ‘HpN8“>–sZ‚ìÉ §!bÕz®`ˆ¹õámž£¼­Õso—é9™·=gâír=§ð¶NÏ™y[¯ç,¼]¡çJxÔµ¢ ˜’ÙœÒÔ0#ïãfbú’ÁêÅÁÁÐ’ÁÀâàQcPÕÁ*ƒïµa¾×¯{å]º?¯žƒ±=Gx«é9Ê[Ÿž“xë×s2ozÎÄÛF=§ð¶IÏ™yÛ¬ç,¼mÑs%¼ëjŸÐÜV]Í°šŒšÔÉpåÈrksåmÓYkµ¶„X»®ªÃê{ˆUËvkÜÃÿAß}GQÖ¹
+e«koÉ™ˆk0Õ–»Œ,aÏ{átêjTPÕQÀ¼{MF‚÷¤…÷£úŠ©ýZw®“¸ø^»tµO~ú’Ùî‹éaw_ˆuÿg¨Œ$§ºCl¥ž£¨ö«au˜ûFýëff†µa-«¦vy¸ûÕsÝ„¸œ-!Ö£3T3·–`²ŸÉ~–+C‚•&ƒ»gÂšªöÍt‡XïíhjØ˜)Z¢ˆ­²w.ñ©Ë²jR=—å€iY:Á]®5©Îhâ	m(Ã”äv›ánÏOr23­1S2;=‘br2ëa¦d†»¼;ŸÉjªÊä€6”íöhÌšâ¡Ëš«dÔ{-¢ÎUIf¸0Lþ,3Ý5+“œ?'Bòg¦.õÖZéë+òBUUf
+x¡õu‡ØªÅ!fãCÚ0_”K±‘…|3§6§ÂjŸæ·Ð©rº
+¢`ŠŸ™üë–&1†ï¥íii\åW/¡$YW†g:wn¹(â¸®©aÎÅ!æN¦&<›Ò)µ/Îµg0ÄÖÜ6ºÉ3qÛhâžÏþ¡'’:ë	þ¡tÖœQÕ>®c3ÝïÊ”d˜µClPl™ëgÀà|–•i	cë\A5µOkÝ…ù‡ôœUö'ŠüUzøÿ—ó=q?Ö§u{¼KôÅ›.Ð9¬çÐ,re­žCoÐËeÆ	-ìf‘ët—aösàî³®–[ÿý#zÄé`±–ÕÙÊ–ã\ÔÔ°:4£e‹Ü×¹B³±`ˆmÐç€¡`ˆMès Ø¨ÏÑ³IŸ#¢g’ãCl3ÇáÀŽÃû8¶ê—$ƒ!–Ò/ó*biý21ú¶é—‰Ñw?Ç#ÚÎñô>Ž' O@;ùšƒÁËð59åkr`_“Sgm0Ä¦9vsìá8Ø+è†Ø>A‡öº8ô~A‡tqè€ ‹C]:$èâÐa=‡¾Ew,±pM0ÄŽr¦‹»D0ÄŽé9RÀ9n€ç!C
+8'ôV-ÎzRÜ‰'N â´rô‡õ) œ1@Žð'ÈÎê9ô/ÎwNÜ	ôG£Ÿ7@Žþ=G
+ Gø r„z«ç{LÜ	ôÇ£_4@Ž~IÏ‘ÂÈf#<©Ï•Š—)ž9™Jƒ)Íëñ¦Ó‰ ³ìf’oâT1X‡xˆ¥PÚ-•A‚Íñ ï“@÷ÊD"DÚ*I";A$²A–e³l®²ÛLJmÐáµ{ýv¯]¥57ß%WòL*ûýi:póë AóÂ¡×Pƒp<Xí²˜eJÈ(AÀº1P*eùÔë¥q 5pû}>“µ6XˆvvE:Üæ@@kP\.gu¤£+æV´¹'ž˜y3üTy[{o4ÚÛÞVþTøÍ²ù/yþÍ†îží[Þº½§»áM¾ö*€zè<J¡ÅU¾›2¡49I"×52nç›b]thvÍqDì»öíÒóW>Uzþ
+ù~¾ÎçÛÈ÷oqh7¨—^ƒŠ¿Z^F‰ŒŽ0çDŠ³K&2Èy(0ÉŠi/$‰fAéº1È2Éš	!ëÉ¸'ÞÈfæ{!šÍ6r:^j·;ü>_ƒÍb­ú5EÑîÅ—hT‹FìùD‰c¬oÏÁÿUëSáÖX{W{çÉ›Oµ÷íóW¾öfCWßý©£Û²½m‘÷çŸäû™ è
+:!q
+I¦Ò^.žÜÓŒ™ˆ,È\2%(á¬R¬Ë‚»×%¾ö	ò½ü_“šü»tþÌ§Ïälè—y+µ¡µÐãÍ T{tÌÄU(+œ(+ÊjËjv”ÂêS¬î¢Ì«]NEëêŠF;·xyfæôé™™ÓÝÝüWöìÙ³Ïòß¡þ•›Vö‹‹Ï0@þ•Qo¼ž‰’Q±>!À—ü€4îðj6Ùº,èˆ¸"]‘ˆ‹/b×†gÍþóŽ‰hÏ,•?ò‘K«Ûó7¸-Ü n*Ã‰MBÎ_%£ž¯€È”Œ¦áWI„!®ÌØ%`=Æ=ñêB§,#éWìÍ¡™¬žEÚ#vCŒ\÷ÈÇHÏèöY=èïšÝÑÖ³g;Ï_k4idòæï=¤Õ´6|µ„RE=t)D–‘¥„rŽ›MTlÙ¯g $YJ¹5–Ž—:šÃïZ&¸Â¥à6—]³‚à€ÑÎ*•Ã±®Q»T¹µgtã¬æ÷Ef×j³´<Žuu†ûNå_!«"íMþüÉªiÞº ÒkX†Æ¸¯¼ŒJ’áŠ IBó0^ãkRòz£±¢2˜I\A³ÙKƒyë{Ú;õ­Ë?X{aßÈÁ•mãý‘‰'^éXÛh†wul˜êÚ¹*¶}¬u/$xnÐUôšÐK«â=-Ä$É¦ýE]7f*ª*ºlWÒeÚ²†uKTµäªj íŒt¸\Ní…‹gf.^œ‰wwÇù¯¿¿¿_x*þ;qÿÖG·Þ/.WÛªÛÚªÛ„ínÐ•tnøÑ”qß;
+I&Òû…IrÒ¬‰PºžŽ×Ô 5þßŠ:¸Qp›­5Áê §­+Q³û¿î óíS«×K|ïCÏ8Kª×÷÷ììJœÚí^ôtGËÎnÞþ¹Gõ©?Û)µötM­>ÜÿÐÊÎŠÎXw¤¢s%—ãŠ…T§×ÐˆÎx{5¡Ä-QPJ$HÜà„[7`©woDÀôÞ½1V-T¾3ÐØ(æ'œšËYívhþî…æ­þûÛ¢+ƒ‘uÛRNŽ?Ø²|<¼[ï\·eûªÓ[ÊVF2ÍÍm!ÀRV¹búH»¾Sm˜Ôü%å•Ó{{8O{ºi;µ¡
+*¦ãVJdTj¢‹Yn0†ƒPˆÉ$Tq=WÅµÜpxäV,ö4z7J:^áp8TÇŠ€Óç³™­ž[&Äµ£!Ð¨Ù5ÜÆüÞY³k]ozÿþtï:—y–øc±ö–®®*ïèè¾xñâÅîŽü?’ÖU]]«š?ÖØ$lgˆg681ú‰H‹&ïàVSØ€I¦”ÐqOÜmÐÍÕYÐ]IÇË8áÔ¾‚;_$÷–©¯™]â…¨,¼P~Žôp/”ÿ’áƒÚnÐjjƒŸë€“Pâº[FïÔ?|¾`!Â7ÆîTbX[TíœW'ãSzÇ
+ïähúìá¬¯YßÖ¢¯ðnKŸ;ZÖZîq:LåeCƒ·oØìQ=µ®Âí,áÛu8¹Ï¡†EƒKxÃó‚:îÐ>wÌ<¸ËùÝÆ’Yz=ÿÆLYXàñ?£?‡†5û…EÇÅu mtV8Œ7A¡ÙËU¯i	€³ª¼VX}^ÅZÃc­¡FšË.}g@ÓFIÅž#GöœÜØÙÒÒ¹‘ÎŸÜ»÷džœl
+×‡›@Ñ±pƒ„žÔ!_e#”Ø‰Dé(d*“½fb2B²È¿C:.àªs-¯uÃ	ÎË­<¬ÚåòŠ\#æV*.W„“2éâñcç?ïÙÔ5á=4Þ·òû±¶²§Ï=òì‡Në%‘¾øÖæ2×Ûa±tô
+Yô-Ü +¨µ÷ÌôÜÒ–ZÔü'ù ¢ýõ“OžþDßÑÊÖÆŽîîÎ¦HÕ‘ºC“eÏœ;ûì¹~¯¿7²¹³Ç¯Å{“bý€|‚ÎÃ!òYæþ”Ri'OM†¸®’C‡·Ál­úÕ"Kˆ4+qE\ipVl=<>1=={úôŸV8møý±¯~õ˜Ø#nÐåä $ÔÇ=à{ÛÊ'ÞI	ÙÀí’]²ºƒ±¨×ÕGÞ¹qú´Ð‘ í ×„ïoëBd2jâI%d²IšhÄÇîø›7b(ŠYëêŠ5ŠŒB áø•Ûüí¸ËçOžZýƒžîhW÷Ê(Ùr‡Ï8»yHx|áûKcè’ÜnÝÿCnW“«:;Wñßbˆ<}útzÛ¶ôÃémbíÞ…´^~ü¤áú¸3'†3÷o$-æeüáà]¾[2b§áÚ—óôp‰§÷tíöÛ]»Kóýq®ýzþ¢oß±w‰g'øåÂ	ò ý-$DGXÍD*^Æ4áù‰Á~—¥ãÖ%jä¶Gì¿<7#=úûs†_¤Í´.îïl*QQ“L$¤¢Ÿ.—ÝåâÚãp»#±XÄ¸JZc£f6kÒëŸÜÒwqUPöEžxöq¿ä‹ì£´ü­Oú-þ»ùï?¹té'ü%&EãÂZw‡lÊ‰L@`ÈÆ¸¹M6”Þ)d¥bö¬Þ1¼(¡o<^”ÝéÓ¸l–žªÝâ ¸M6ä‰Ûd3ÛÕÕÕÒ‹µ/]Òsù^!! ¼´°Ÿ|/CBMÜµDàb°Û¨µ&È9ö¿¾ùÄ¡—ó_3âMLœçáâgY¢„$¹ÍÒ]†R¬÷9…[sØ"¹¿³`¼ö¿-knii.{®éýSSïo¢óù¡Î>Mëë$óùm{Î¬^}fù¬qÖê\¸Aû¨^„ðt¼ÂE$ÙIxVm6I…ô@…b¢
+?hÊYÈòè8‰…c%Äl.ÞpÆ7ß}§…±oO=¡½Ñ¯Ö×º«lå¥^âµZ«ƒ^n‰DD´hP
+	¼FÄÅ-gQ6ÿ^)›Ê7÷n{wRïÐ{Ý=G'8á¬pç:7è­Í¾¶`GtÓÚO-k7¬XŽMe^¯p>°¥Që_QïôpSÁ÷ r	sP¯^4£Œ/±¿K‹’K¯ÎÍÍ-æÄM¯ÃÊåBãWÅŒ”˜e	Vb•­ÕÁHCá´q½õÑY»ÍûÝ|“ÙìÇ@àè**£DÈp«3’²[6W‚—]æq]*ZÛ[¯þY²ÝÒž|îU*¿ýÅ/¾ÍOxÜžtZGmXŽ|³pÈ¬%&©ŒPE!„šˆ<êòíûòÂd2Béè˜™(Šðic\…ùItãž¦M¤â~Èò—±”Å@Žkf¢€…î¿ã%Xét¼²®®®¥®9àô´‹uyÐÏ=e!Õ‹Þn¢Ñ½=>Õ=v~fí†ÈhoÏm–ú‚¡®8þÈÈŽholo¤ûƒçÎ}°»cGþlSã9n®Ñ®~Î7@'é<Ì(E ®AˆŒ}àu7Å2”Za†Y”3jƒÞFÍ¬9"¢IrY-ø±o¼õü,Ï|þótþæmÎÿVèÉSøù.9õÇÅõ§HüO?-ž{yá­¢¿…!Ã¿—b©{·ÝéVÒWÜîXªŒCçŒ[ÓèËÝ;zf§/\˜žíÙÑMþôå™ààßŸÜsòïƒ3/ï ÁÐÂ	òÒíës’A.?@¶Ö&X\Çgä\‘zê"/-]èG·¯³°`Ø5¡^€˜Åu%9B®’I²^ÚEçaMÈ¡p®OŠT[Ð4@Æ­%•å%6«Í§š¬5AG!ªj±Žh´SÓìñŸ>93óäOø$éüå—^º|âó|.ß!xêXè¦ƒT†ñ•¥”7XQ„9ÜZ²Xè!IQ4-éˆÅ»#/?ÿïîñøžL]Iõ÷?5Òj	Qùæz{Ž-ë§äGÏ=gÔú : ê‡áxP1QJ;…6ñÕä·
+d¥(µ;
+2^Œ37ÆøÉjÇ×KžÎ|îg³§É[ó#?¾ùOõ@Q+|?T ïUx®G%™b/E0)9f..PQ^&Îv{•ÝÂë"Qo”ð4—Ÿ—&ó×Hõ•mÛò_þVÉãçÉ•|üøã¿#~D Ú,d±é+f®«£âÏTâ5¼® rT”FÅž¸·(T‹Ätþ®±t¼€»ÝÎXÄ¡¹´¨×%½ø«z„üú_hü‘ÿóèÍok‹‚­"ÝQ[„,›vòˆ>`*òx$_¬0º¼®	òÍü?úü?‘&QeüÂ>·ÐÍÅÚ®ÕD¤¢·M.ñ¶¥(uU	o]t·®Ÿ¾ý¹õ]–®õŸyû7ä/_xâ‰ò«~cÄ€Æ…ï(ÆíÂÖ#ˆá4ø¶‰]³óm““Ï½I›èê›ß¢«ÏœáóH¨_ø0í–‚P€ŽP¼¥¥Ù§Õ»«{…Y‘%Ø¸î´ú+¸-ºüTìŽâX4ââU‘F—q6»4ZíŽ*®ª@£«+zsÝQßÖU[Ü;vìÏ=ž¸¯%n€}^ÿÐ¿zÃV%Ú¹¦üªlß¿aóåû÷UŽfÂŸ“«öŒm>n?@Ç¬Ï—®ÉÿJ+ùsÛZƒ-7hŒÎCEo¼»¾În“e×zj¢Ätž;X™šøÁVÙ	EB”vA×~_ Ánã'&â5Y²QÅáÞßpÿFÏá¥åùoØJjÖ¯êÉöÄÏlù‹M=ÉH¬§·#©ŸYFr4övtet÷Àð‘Õßîìë´´w·Û	ÿ£APT,Ü [é5Å¹xµ­’R6Q‰†|Ë%Ej$²"r•«RP;ã b!Š"gÍ&*ìÊ÷Ý"J¶Ï”åGåõ¦ñtÜ©ë€Õ;D‹ÃîñK¬£Ö[<o-9® ‘®hÄ¥)f·&Ò q6Qî£©Ð‰†‘tlx¯}µµ¾Þ_×µ²M)*­ô“fóxÿ¶šÔTE‚e±í±‡[ýíÃë"1Õï«3-®]ßŸ=”L~2éy°éEwdG@°½PË7a…8ù$yd¦™[ö`‚ÉndvnaÛŸ':¿ù­3·½+á9	{×%w½)!âM‰øjä{þyöüóÄ—ÿ1Ïÿ3ñð7%dá·€ôT1¶—H/W‰¢ô¢'á‡Qm‘"w$æ(\%MjÔÌ’fy>á—ô±ÏŽ%ò™¾”j´ÔËt>Ÿ{ã²Á¸Þ"üãùÇ»¨NçQ7¼¼¾«%£
+1´–'´×Ãj1ÕÖTV¨õ5ÞZoµ³Â]énV-‹ÁÈìÉë(V^\· ±ÿØ}øè¥wåoüMWkk×ÊÑX{{l”ÎOßwÔ«xOí#ñ…êCÚkùú[ëÂ¿öåè·q­Âj"ò­4Q–Œ
+ ;ìU®*Ã¿6\—ÙaÌÜßºò…X‹%Øý‰+ßziMÈ¢'ˆ’ŸL&'ÿßÙÁA®Â	€V‹\T7ó‡ð8F6 b¤´³ #+­²«E‰—{5¯+AVäÿ•¼žÿ)i>CªÉÿBÔ6N R%‡j¼Îf•ù›.Xª
+	³Ýa¯Q×lnl,¼TsDìšž\z,*}ø3A¿ðÂ‡Éwöüæ×‡ò­t>ÿ*¾9D¾Ãç_·p‚VŠ³pøÖY„KX$1VŽô_ïÄ‡`!ëÈšÇò¯ÂFÝo”^G9|qo©ÕLZ“8ós.ÃQå,¼²ÙlvikfÍƒ^úöÛì¹v^ëÛ¾ñØwóß¾ÞÎ_o7 ä¿Óë…’$‰(18fâéÕN^ƒ¢(ã¼‚¤ÑÁ+GÅ·M¼‚d×Îmß>1~ñp…óØ±Yòì±‘Çœ#Çò‡õÂþ‚.wÄ[Kˆ$sM–!A–öÂd*¤Ôàye…¡¼öj¯ÍÌ3­P74;4I‹-*í;³¼t¸¦ç‰¼WïãÕÃõØò?'ÒqQ@üŽÐÎ¦w(_ÎÁTžW^@y¹8Ggg©|ó÷ ø	!géÏ!¡1§LÄ—s‘l-¿–&Ç9„ŸÀÎ~Šþü“ŸäI)(puõ+ØYÙ÷0KïrsþAÙ3ÿÀÛŸ]³ä‡òß”_ÏÀÌqÅ‡§_$ÿK@fù¡üßÊ/ˆ™–~4•¦ÐLSXESÐÈ Ma‚÷‘70Ìû¥¤)h
+žB»‚¦ÐKSXCShç-Ñî(M¡ƒ¦ÐGÞ@o¸žþ/¥¿‘¦ðM!FSè¤)|èb.OaÌDSxŠ¦ð2MaˆÓâ4§‘¦PKSˆè”i
+54…zškVÐ¶t/ü–¦0FSpÓÒœ )¬ô¾N/ÑÍ?Ð‚}ø~‡ßÙEfÈh=Bßª¥Ò÷åù€ü‚ü²|ÝÔa:jzÑôºR¥L(_W®›ëÍ3æÍÿhÙeùË§-×Jv•<SòÅ’w¬NkÀzŸõ’õ«Ö+m*½¯ô|é‹e´lsÙ;eùò@y¦|®ügU‰Š}³×*•Êå•}†ÌÀß û €â
+	àC y·Â‰ŸÝPŠžxÊ% xbjÀü½áÑLaÁÇ
+°„8>]€e´álÂ2b+À
+ZHK¶ ‹l.À%x†×*E]V€ËÐ@ûÄaÁiÅ~ìÅ>‡Š´¡1¨X‡Æ 
+¬£8‚0TdqÓP±kÆ!L‰þ58€P—ÌtLÜíÆ1ìÆQœÀnL#\xn«À;.FTlÄCÈâ8Žã(CÅ$8Œ˜FÂhß^lÁ¶b½bŽ¥3Üþü$B‹Ïÿq«©‹ø÷	œcØÃ8$xQ\ÿ_“ódàØAQœkŽb
+û
+3L8Täàöãìx»°ûq@‡Š	dñàí	Á}Ó…Œ"+z¬ýØ½¸Ç"æ&Æ1AÇì.`nÀìòà˜›°û]|ü˜˜¯Í%xGÐƒV´â¤øÒãXé½0²‹¶ðw˜¾ç$ Ð®·ÍØ„-Ha.8P‹.Lb#îÃFÁZa+æ°ÄNlÃ0*ÑØ±i¬‡ü/1ÊP‡Fl‡n,Cúƒ5(A+‚è÷ã}hCÆ±Qüü9F®âÛ›R9BžN3bü5å‘Ì‰W€ÑU>-ü.^±S™TÖXVÊÍY±:wÓ4]§¬¢íJƒIt–'^«¶óç­çÍ€‚Ò–‰×ð:^G¼ðå½¯òt ç#—6¦XüRŠßOäšøýUŒ¤=¹FÞ5o9"Ç/Mm.ðO¼bŠn¥I¥—•:“RÑr•,<Æäå(.›¦ ø¿Zîáú
+endstream
+endobj
+303 0 obj
+<</Length 13/Filter/FlateDecode>>
+stream
+xœûÿ>  Aº
+ç
+endstream
+endobj
+304 0 obj
+<</Length 684/Type/CMap/Filter/FlateDecode/WMode 0>>
+stream
+xœm•OoÛ0ÅïþÚÁ@{èbKrÜE€Ö©ºM±S‹É4²á?‡|ûAz/í0ìÏ¤HþH™I¿½l¯î]÷.Wæ{¦^eìæ¡‘«êi×'iºîšù(~ú!âÄ­ã­ê‡®eRÕf½ñí”¤éÆ7³“³Ïÿ\äÐú/‡CUó8uÇ$MßÚéCnÕ¨X“Ú8ñS;Tv™¤éOÆ¶ó·*OÒôÑ»ª;†âÆdÁjñ2tÍV&µo½˜I½‡¼I®•k›‰*~7Ç]oOã$ÇßwÊÀËÍ==•Rjñ*‡vœ†“ºˆ…]*'{Xž'Cëêâ\ì_ÆíÜ÷ŠTY|*ÞÅßE€ÿ±;ŠZøó))UþõèíÔ,~=uî,r”ØtNÆ~×È°óIî²,ËVê®®ëz2þc/K{ß7¿wCtÏWê.Ë
+»ŠJGµ¼†2P”JgPETÖ@-áYA•P5ÔuT%£ÜÀÆ|÷ˆ¹†z@ÌG¨
+ž9ÔQxî¶¨¶eTyh@–Ù
+|%êÌÁW‚!Ÿå9ð•
+|KT–“QÈ‡:sði°çäcLð•¬|Ë(òÑ>Í˜à+Xø,:¨Ág¨Àg@¤ÁgÐ3>ijÎ=Óà3 Òà+iŸå9ðô$*Óà+XøØuàÓ¡ÉQÏ0ø,nˆŸAL>(|s0à+Ð3>C>ƒªøJ*òÝC‘]2äCe&ðé0œ¨È‡‰ð¬…|Tà³<G>ÜVÃù!ƒ_‰YÎž–óC|øjd°àÓè åý¤'øª¶O‡‹æg™ï³óýÃ,îg‰.Y¾U\+ÜaÁ„=ú¹ÑšyÄOqÆõvUëås÷]NÅO\äçÿ„ žë?Œ·™M
+endstream
+endobj
+305 0 obj
+<</Length 9336/Filter/FlateDecode>>
+stream
+xœ­{	t[×uà}ï/ ÁŸXH
+”ôÁO€ñÁ	qàN‚)²%ÚwË’,Ë²c9²“Út;nÚN“49§IÓ${äxcšÄ§Jš¥qŽ›ÉtËÍ$mÓ4íQ2Njsîû)K¶3gHÿþÿî[îòîö> @9<tì;wVUî	\€?€¯<uèÄ'zÜ@ ¨r:~ßÁ—Iß¨þ@ËÞÃrûí'ã¿è} z>³ôg ‘ h:|âìùWº6žˆ, Ôñ»öåþbðëa€­Ÿ€ÏŸÈ?%|Î~@_
+ Ô“¹Oø1@ß) NÝuæ¬çß?×0x
+ þúÔé§îÿoÏÀà7ÿY„EH@‚® P ¡WŠ×¨½x­Y×vuMëÏÍö$ az…ìÆÏmñ¯šøQˆ">¹€Ü[üuéž®qú
+‰0ÐU‹éDFU'_‚ª¹I&oß•fÝÖ’ÉT—ÓŒúr/[Á
+ûöi{=^/ƒƒ¸6rÄ³± #:S³ƒŒêšWó™ «ûŸœ.ˆÅ™#®f³±<uÆcyŸg4¾p^e£ñxn?Sç/SJãÙóhðâÓËU.kPk±ËâˆgcƒTú@æ²› f‰:ÌOã|Ì›u¿Ê^I1Ñ¿ër©Œ'ö%˜œH{™àËÌß‘öj^ÏrZe©TÚË¢Ê"E25o`çö³–TÚkÞ©¬Û;ó•TZ=¨./çTfK¥³•©ØfC¨¡ž¬'›Éd<ŒúXE|ƒù4ƒIDö²Š¸g’mBhÓdî%;ìCŒ—$Ø›ÉìÏe	d2&u?sÇµX&È$]M¨Lôåö«ÌO¥™E‹1«óx½F²A&sv3! îÏ[öÆTlDr=Æòñ›ÉÙÄ>&µzUf«Ëê2#|‡äc¢.Myró™´–ñfTÝžf$àA¾˜K	2‹ÎÊâË@1[uV¦Å4•Ë1º÷ #ûÉ2Kk•é*®¶*¾ï%öª8‹f3ˆ’á«µé—Ëª žˆµzW§\_¯HÆ($ 1ˆ3Ñ—UËZ…Ê™S=,ºÊ0&ø´Üˆ1Eåmº³¦T;GoÕ©
+õ_‹=WYB"•öz4o¦ÕdÕzžÒÛŸ	2»ÎHVUYu|PYµË0;ÞÍ§UfçòRt•Ù9SÔ—DØ·¬å˜ÏªËY•)ZL²}r!÷dšXåí|9ôÉ¹ôävã¡Ç›ibþÜ©ç¡&¾˜Î×ÔÄÉÅ˜À-Ç¨/–¯Æ/;õÅqk*|©tÙÇD_lyYÅií­^‘\	öíØ…úø“«Ž2{|4ËèzaÝF„y ‡6ÂHœÁÐeB—–K‡<ÐÄBšÕh15Áª´«Ô˜œ©Ì©ÅÔ,#¹ëê(à€X,†œpÆ³Ø–wZìñ€§1dn=®@Õêy‚×:=OñZ¯ç¼nÐó"^=z^Âkƒž—ñºQÏ[ðºIÏ[ñºYÏ—á5 k%A09;¹ÖÔ6Fvã¶	2}M£{µñn£1¸¦Ñ¿ÚxÚhTu`ÕÛŒ´>oÐŠ„®¥Ï«çAY£ž'xÕô<Åk“žðêÓó"^ýz^Âk³ž—ñÚ¢ç-xÝ¢ç­xmÕóexmÓÕ®¹íºšeuY5®1’EåÈánlCåíÐY{€µ·Y§®ª£êmÄªå"ZøwÄð õ]%Yç«äªëlÍKÄ•Hwd8•¡5ì¹N·®†ùÊÃ:˜8‰·ÏÉHà–kÁçàþ"w¡#CZ$ßM\Hk®¨£·Y?ƒx.d½z[í@EÞ•‘ø¾HmÕóÜ>µMEÛÀ¨o|yyTÕrjz¯Í¯»!Äål²>›Õj1&ú˜èãhù
+ˆ±òxàÀr›¦ªË‘ ë_¦¶ã1Y‹•°U–EãK?'ª’êyNôK214¹¶¸º¬ñZ2ËäøÍû6‹fÏpOb<»_cR<·?•fb<çaR<‹&ïæ>9MU™è×’¹ˆGc¶x]—-ÎgÉª·šD3Œ«Ï¢0$_ŽIo•‰~\„!ø²ûM“zc®L”x¡ª*“ü&/´H®61oOj£8)Jqh•…HŒÁié6u@órÇk>Tq]¦(˜ìc’o|mcñVÚnJKC•ß¶f%ñ’¸²éÜLrIÄQ]SÛ‹IVO§<ó™´:iËwg È†×µÎ{RëZc·ìûN=â:ë¼Ó„#:ë,«ê êØräö¨LŽ·±Ž@%8É¨Ÿ~ƒó9V¡ÅÒQA5u@mÓ"æøI=o}±R—ßP¥Gÿi1Ò„vl@‹x¼kôÅ›1×9ªç¡/PâÊ˜ž‡þ€e†5©YeÁ¸ÎÀelûË€;ÜÑÆzZƒlâ6Ï'õ<§ƒõ¶Ù”Î¶¶Ù4r1¡©mjrYË•¸5££B³é@Íê—’ Ké— 0§_&üÉ¼~™ð'Ûg4dˆƒÀ"â °qØ©? ñ@¥õç0†
+YFŽÏvéÏãÙˆGºñ8´ñ8´ñ8´„s&A–Å9ÈáœìÅ9Ø‡8c Û8@"‡øºFAv˜¯¡#|]åëBè_BÇùº:Á×…ÐI¾.„îÒó0°*ÀSüŽEAv·‚ì42ßÅAvFÏç¬"Î=‡˜8çô<®Žz/¿ã=Î ö¸Ï ý‚ž'&Âýˆ "¼OÏÃÐêxò;Ž~Ñ ý!Dô÷ëyb"\2@DxØ á=ÛVÇû ¿ãè4@Dÿ-DôGõ<13@DX6@Dx\¿\ÎC\&{.‹TH¤5¯Ç›ÉÄÌz€	M©ó%gDKA ¡°À–¨Ÿ	@‰D DØ)A K@2+Š¢E´Ô(vI®8¼Š×§x•Ö]ÿ	ù›BV¨xëÚ ýÈõã êè6ºðF7‰%„.¥ñiT˜ XE‘lõ¢hŠöºÈŽ…¤~z÷õ'éÝãã¸6{È[ô*8 9ÚD	È $¦AH™š	¥#tÆ¡94»dó!%Ôêr»Méök²KÑö¦Ä-Gçs©¡ðdŠ^-|'{xwáy2˜L†:
+EÄ‹×¨‹Ú¡a0ÚçrRJÈˆ@¨HYˆ$A ¦¦R!'A˜fêëêë½› j5§ßj«¸ýþpw®Àíry]Nw¨«§·V–5*Ë.—7Üí×~z²àXräðÖÂ¥c¡)WÝ‰‰Ždi™VÄ.ÌÍÝ>=î¯K¤Û-=Ãä‡[ÆtKùÈ"ò#Y¼F7Ð+°Ú¢Zw™Uäë$„/oÜXŠlB@&o€zŸ¯	™ìÆU…ºÜµ?gÊš…ýÙÅ‹îÌmsoë›Û¾}®o›{lsngÅËŒ½¼=éíí»ÿøéã÷÷õz“Û™ì€_Ó«`CÙ!	œ–Ü÷0C Ì"‰`#6Ñæ„ýa%¤8C!×s-ÁT}¨ÍG?|ýþú$Pˆ¯Q7µC5l=º1x,¡ÊåDBÈ™±Ûìíµ.¨†*¿l«]Çb§,k==ad«IÕÕ#[·ãß‰T*ŸŠØ…ùù1ã;±}n	˜C‚ÜY¼F~IEpÀƒÏA~òt>Z#B’œ¸œH &`Æ3É*Ré¨ÛlÅ£J­ÎÛô»]—L&ó¢âÐ¨º>MÖL~¡pÐÈgÖ¨nj!{x7™,¼ŠŠK^‹ïßâ5ò+zì°	ž}¡¨$–Hh J8©¹Yd®ÈÂ:bÔ›p@FLÄud½óXï>L&“‰V)Š²IÙèWM–£fÖ†\ÿ:Q’Ï‰]'–Ž[:Ñ%¦RSSS‘ÄÌLb!ûäÅ‹OfI÷õ†þH×JWda4=º`èæÇˆL¾Lv ›¢À}±Ÿ/QB€ÌVúE°Õa¯ëc¤‘ÈX.„ µÒ(Ç~2P$¢»œ6ÕZq(5¢mCÀ¡)šB#£hŸ²LÝû3ËÔ½tözž®\‘Ž_/éµŸ¢4¶À¿GËkJJ$™šBÑ‚,Qù‚˜Qœšd±R€‘é2b±”nV…´å6}¬¤Ô…³}‚”¤õ›MòŒbôlÞL`ó–Í-M=n§½ª¼LaÙd³¹ÞÆfSª¡—¥¥™ïU.Ñ%¬5âý×¹r©éÞ¹ìßŒöïÑ{\'î8æªnúIêäòÖ®…ìÂøï…"}S-úÀî¹7«]ÉÞÞ–ÅWs+è ¢+àâKãÓ2¡TXBÓ‘D'Ã—;BfEQœ^ÍbÛèuºqZ£ßV´p(r…\Ú¿mÚºµ²bv)têTêcûBG°|Ä3•$Ž‘^€b‘ëï·éUh†Ùâ1°
+h7¬y ÌÎÂ®wQ ZGEÃß	„™" 9-îÉpxE´ÕBBÈr„„_½<÷Qñ£³/S±°üWÜÌ"ÅkÔF¯€^Œ–WUR‰Ä’æl	DA¥œÀqÜf“×mèÆ[`ÉòˆºnK¿Ûxïe(Ô›¢8|¾&ÎeŸ&¯îé›¼M8¬…Ñ¤ý©ä‹ºû÷exÆÜC}óss±™ßùÑÌîŽ­/>óÅ•Åooß…ÇO]œ‹Å‚!oñ­ vð£ßs»(’©Òª¦Pâkýž|šnø½æ^7Ÿ»ÛßÜÜFScá‹rºkk7Q—SÖ>žéñïêß6Ñ˜ëœè9½ç‘™îžcƒÃ­s]ásû+´oi	ê>U®°Ô÷wOÎnïnm)ÝN-…¥b„6P»iƒ+é:,Š3´í!Í¥ÈÂ1á†ÆÖõ¶õf<ç»ŽõîÃ¬µÁŽ&ÍŽ6Ør“SÖ›5Eƒu6x)µÆ“ú™™Ddj*BEÓ
+®Û_n‰ù^Ø@kè
+”ñ½IA©pMñf1ÓÅ¥Te¸=eÛ†@Hñºø¯²‹¼Tø8IVèÊø?^5ìú) ò'T„JÜ_”†ðK¬@_#Ì8¼š›hNntŒýN¥$ÿ£ÝÓãs)*^º”šßVø[ š¨šàÉÊ(V¥å’	²˜Š[$Ê‡6ÅTÏù‹$‡Þaj-‚óö½ß¡#J¤ƒW‡¯Énµm2VÏ÷ŽqYÇ®Ù”èŒöö,8©}vh6“êí%S=[Cc)*.CÝá¶~#ÂM$Cí…’Ád¯/Š×¨HíPoì¥›bH3Ä½±—ê¡îbHB¾öÀ'Æ²µÑªX{bfftoëÖºýO?ðÀÓÑÞÆ}g2Ü¹«¹wxMLo<ú¼ÀCzƒõnU‰J"åvÓd|­¡Ø«AÿšfçízÞ¶²¼ €|7Õ¯´	n0ymÒ€ê¾>e ß)ž!—àQ .êZk †ŠÚê¾ òþ3ñGÿÌû$ÈÓ«¦ß¾;ÓÁŽñ&¹•gÐk5)v´¨ôUïr•–]èµíÙÃ‡CK³îÚ­[7=öXŠ¼2JNyFÊƒÝ#…(Ÿk@è¥"81wª¶R½’$a½_r‚Ó©¸\ÈGmm¨·7d|š Y,šð±pœNŽÍÒXxòwö]¤¡ÉÜG¨ø_¿õgöÖ\¹þùÝ?þ9IâœG è½
+•Ðõ–Û,ÔÐ-ž²!qæ´Ž§¹UœÊâÐ‹K;’w}aïÿºïÏ3˜¥?ñ­ÂR1÷%#O(êäW\o›áZ´Â]NeI–(¡%÷èI24wjÚBd™3wdº¤Ùc«Ò¢˜Ä GÈÁ;";ßë¨[Þû¨ÑF@iÃÛ¢sÍD«7lØÐ¼Áïw45iV[CÀÇ-t¯;Ô¯œÃ!º>lþÕùcgí=‹O‹]'ö?¾M÷ÇÍèY9va´7òÑÙ'.\x"»PHDº¾€!ôÄèø' rê£n´TÜh{)tö¹´09~éá‡6ä‚öÞGW j¡+Ú^FÐšÊDDáHn	Ÿ¦F$]]åvVÕV×*n¯Ý‚{OSïƒZ õb˜Ðí×4åÙ…BöPfûå=Ÿ¿ë³áþþðgéÊÑ¥ÅƒÖÂë¤u4ÜÙÝ.:·k5voçaïMþDQZBO8"!åPŽNGA×·êu\^×.òlá3d¦p™ìâžçÚ8Ž=Îë+Ð¡h‡º¹F¡RDˆG @ZIŠ£™1<-qú|þ&»lk¯Z“§6úKÁˆ!,K³ÃK~Qø¦ÓÒëÌöl=>ž:Ô¼MMöÎÌŽ·n­'Ð»¿ðû»s±‘#}Ã=íí3	kbfÓFÁ÷(0^Té°€6cåD+‘Q:RJ2Ç§-<–tÚí¶ZÜ›Ý›<õV—ÕY]	Ë0­Vì¡.Å~S:í‡»C].—S‹\»vmnjj?CCCCä9RøýÂïßwòôÉûø×ÿêpwt¸ña º…ËeKÔ/K‚€VxU„,n©¡$¯…0@´4÷¢A^ü¦…u¾üðKã4ôéð3×Ÿß-ž#?£o‚ü“¬.•Ž–£µý ÜZe8ï€s™/Ö:Ð×ôôô†Ðh:ÝµZ7²§on÷}÷ížëÛ!¿ûìr ùÆ…ÞH–ŸÅÂ8Z<G_?ø V:Ÿƒ ù  ¬ÎÑ$Ë“kÍ¡MÔE_;É¿ÕÅkT¦W@‡‘èp¹q	ÔÍT”„)¿%$Tb®Tã¨ÄÜLL3[0ïªª°Ê ÝbsÈ*é›ÅuKµÓÂ¤jt2Ñ­Ý6þøÀÞÈä`tÇÀ‰±…£ÍÛ6OŽ§f¦¶“§£Ý–ž¾¶@Çé-©ÞèBµX±kbàÎ×¿Äuhdå[ŒPŠ @ctsu9E÷‚Ù2/},2FVƒ2"²¬iáPWo¯À=ù~ªŽ­‘©;6ÙÚ_›ß9-NSñúãí-#ž3ä×?øú××çåXk ˆ ‡°ä‡qäj‚§˜»SsÅËË&_,ü|aØÈ`áUºRøé¾ž4x,^£›èðñ@×åã7ç>hj
+øŒøgm2Á‹P<™XÍ&xý—Z·Ü9497œÉ.<pâ““ýêöÁÑ©þ±É:[1Ü×ÕÝ™ÜÖ©¨´ß³ÿX¨Uìïì«¨T?™;‰öt©x6¬ÖsnÊ%¸'½)ÀG§:±+apËBLÉ>­æï4Ö»së\BY›K¸´¦÷’K`A–'ýëR	”ñ—¿kµŽÌKÈ¥5 €\MNž:Lð»zxáÌP|Xùtuß¶m}ÕÞ=»wïñÒ•Âî¹]];çÈ§
+wßýp<þðÝäIÃE‹×h]74AO4d#"V›	"ŽrW‚<ÍI‹jkj›jµMà—ßm±Õ278–ÚÛ(¿zqòìÐñûl¶.…ûŽ%“©Ôèh*5ZñäûrÏ>Ü²ó“gi{8œ9Ò7:›´&gù å´,¾·úÖ ùR>1Áiãõ‰+œ¶ö¨ná´IDDGFŽ”œ×ý˜©­EÂZü~F…`˜·Þf“¥FéÕ%¯#ŠÖ½¨“ÿØ$‹dn"êÉ÷XCÐu~lM-x|}-]×§%ßÖi¡«JMN¦ðs+7Åuk€ÖÓ+OF›ª*© þ©Ä
+A(?n_7b^o¸wu¢RYË)[,^Z_hûÇÈ`<:8Z3YwbÏÁ3³Ó¯’ûw¼Þ•ëªØ–ÚÚ0ºû®;&ˆÞÐµúâ5:@¯@Dà/£Å.”tv¶67ˆ² ˜^ÅxF6ãƒ#V"ËbÎ"QžF››¾éíx¼ÔŒÈRÏ/&¤ÒÆ÷1ßÛph œíí í‘ö^hƒ Kñøô2›Ç,Ð÷®êÊš„±¶6ÔÓÛriÜ#Z3V‹¸nq¹}bgÛ@bscçöÎ¡´=Vöé=›[>%YDúÄ¤ WV]XÚ)UïŒEcŽgÆú*BéžãZËÔ–ÎéÀ¶@£·¹7`Ý<Ðõç[Ž¶ÄÝíÛüO
+6©¯wï®î1r¢ó ‚BWÀŽZf£” ™’%
+@—ÐòÅ§QÓF;Ø‡¢8Ñ®‹ 4›•_GHÑú™þ?ùLýü¥oŠ~ižNÝSxtœ½þ<])<JÎ_ORÌyŒs0áxÉ~)eAS¼<€SñøÇ¥¸\æÉ•cÍŸ 	ü¯>3ÙG‡ÓÙÅaa`vÇs»ïˆÒØîÝt¥À
+ÿA$’*°Â[D$©ëIr'">]Òm]+Ì?oAÛ`êSÚ3 §Q	9sX£àMÂCokËD+°à	VóÀ.D¼.~`÷Q
+1I^/\£§/}kâúSÜ õ¯Q/½Ø½ß8dŠæÆB%A\šZ‰$­†¦­­ ­½­=í[Z4/x`ƒÎCSC¡Â¦Ï]ÞÔ¬Ûùëïþödd2¾÷È‘{‡#ñÉÈÉÙøØx,6>ŸXØ>9¹}a¢¢ûÎ¾ÄŽ«cGji)Õ¿Ãa­Ù‘è»³›üa_OæU=}…ÏÇûÝ±Ø€»?nÈu€6PªÁÕ*mo”|EÁ¨3 @5T×¸j8ÏÍf^mqhÍšeð•/eg†Äé;¿üµìÓâD.œØ±ãÄõÂ¯¾ým °ˆ‡°T„2ÔS,mÏ¢y&Åã+aéFø\e5Š1K˜xQ0^×"™.|…üAá9²sšœ™.<1‚vg3 íãç²åŒ¶‚@$8¢hŠí±ÊmeVó”Öb«x›5‹æ9ˆ&„ÈúÑ¿ó»Þ(ü²lïw¿ñºr=Is…ÿbðF £tl EÕ2‰%ÖàaJ‰36°9k°îUx8è	
+¡ÿ–Ý¿(~iÏ¿‘òÙ>IéÂÏx~Ž|üzaþCHÇüƒ8ÓŠçÈ¯è›`¤©;€ŠD Â¾RúÇ#v¬¾aIþPA ;KÜ£Â¬¡Ù7Ž¢k¯KSB®‘ºïY¸4ôÖ¯‡€ÀRñ¹wý<<…ß·*ˆ†LõX[Áâä!Þ¼Ó\·ÍC/&:aroá'ßÿ>}ó­‡yˆSz‚|:8¥cœÒ1Néy ZKW@‚Í<p‹cIfoðSI1N0v_ “ts&ŠK *·5¨­%¿†Û›R®Q#dÆV¦T—ÕØjšTÉVp˜1Üšt|éÕ‹/^|õ«ó;wÎ£+ì™gØøÙ£Çž½þƒbŽÀ+t(Ì­Ö6spB Ú‚†…
+õlµ
+l®ÜYSYŽÚÐä•Õ›3+ÊjÆ²«=t(ûùU€¥£…»y (4Ð.>WÆ6•?»—pB)æ)§\ª:WðÙ¥FÁâƒ7ìL65—Ï«häBá³¤íÂáÃ…O‘Jñ±	òã‚3ñØ_ÿŒ’áµZ°€Xø÷oCYž—Èoóƒ  ´…×¾ýQÍBi)¤0_~¸RÔ(5¥ÂÜ²´¥`%>HÞ(œ%8Iýã“×ˆóçÓ¯C#X9oS×yÕ£xŽè› @›¡“<\M…m<ÆÎ¹Þ¬F†µ$Dv‘;Ç
+Ÿ^.½õ ‹Å#ðšyÂuŠŸpÍ¬?á*j'§¾Î¤Þù6êÿž|ü.½
+8¢ö5[Ð(†,†:ß&N¯òj(…áâo	}ôëÐãÄ1ÉÚRé¼5T.#Sled*3É6àùg…Ê¡V™k9ÁüÀ<”Ÿ†²21‡ç
+É2r6§ÒÑà;w¤¤ÑJÚRéhHb™(•=ôî³™ý¢áÕ.Ä&S[ÞS?¼ÆÆâÃ}‘Îö-ÍMÚæµ.{U™úI¥Ín„ÛFJåçñÒ§Xû3_wó‹û=<æ¼©$øÕÓÏ,å.ŸÝ÷ÙC‹™¶.Itõë³íí³Hµ˜Ø°±­3õøŽ=¿3?ûÔî¥;êîîî¾ïÀÊ…û¿ztî™‡O}¨­¥UïÜ76¶¯³U)¼æoÈ.´íøÀøŽß»£ÏÓóƒºÚ.´t†SáAôtŸ¤-B ¼ÐíÐmÓ¾¦ú:—S©²È­²™P ˜`‘ Šš;3^u“]°Õ$žl×*FžÝ¹Ü<Žlvñ4ÛâÒ¨»6,Ë.ð7»zzÂ¤ö#sƒ¾¹PmnñÄÒÐÈAÿ¶†dÇ¦Nº¿/6%ýƒÉm#åewwµuJDí‡&·ï³<(EºƒþVéÒæOï<f=HÇ¶VþTþykÅ¯-±^ƒ–´iÍì°š°Êf!Å'I¤š›fÍ‚G<¦ImðÔ(š×ÓÔÐT_«l¨Ù «Ö¦u5|ñ:JfÎuJÿKæP_hÛXçŽpáW{úû{žúDÿðpÿ'èÊÞù	»P5—ˆÜ&w´7·wþïÂWzº·t÷\7ªä^%¿åÛ 7ÎŸn¼™qóI$¥7!ÞŒç|×±Þ}˜w}ý#}ïoƒ,\ï&ÂMoƒ²â92ûÿb#%%¤²¤a 	·¯ðÓÇú¨Û ìFAßÙè0tpšõ-^x%´4+É[·nJyÌcŠ ðKz”dé_ ÍyyÿH´—dg©ØN`mŸ—a„`½={”þÕÑ£Å"ü=L¾L_?Ìî.f?U€š<—Š 9æ Ÿ«ä•{ÀuëÜ[QíøÂo@àUò=rß;Ûîžxøý¦í&pÿkŠ«csžŒ”ðqì“©ù;Jøà¾¶dYªøX„Ÿ 3Þ¨xêxýAòä…sEI|LÄI-ˆË€H
+ÿ ²Â¹Â[âc|¤µ?4*MC=MÃ^š†8ù MC’è°‡¦!FÓp'MÃ MÃÇhRøŒ|:‰9š†(MCûÑ4,Ñ4ì"_ƒSÂ#¥i>6Žùò5H
+À4MÃs¬B\ó3nŽ¦iø.MÃQš†óçšc§ÌùÖÌ;ŒkóÂ#œ¼ï¥i¤iX¤iØLÓ Ð4ÌÑ4üÈçMÃy„‰ÇÍ54škê0éÝEôâqí4/<ÂÇí¢iHó“2³ý—4`Žó*Ñ¹T[a.Áð©#ä!òô ½D?+ìžþH¸"Î‹$µHóÒéM9"\~Aþ©ÅoY°ÊVÕšµ~ÈúwezÙŽ²GËVl¶ÛyÛ7ËgÊ)£üß+bT¬Tž«|¶òŸªZª>Zõ­ª_V·TÏWï®þpõ7ª_¯þ¹½ÑÞjÏÚ?bÿŒý5ûÿPˆâP|Ê`M æÃ5?vœp|Øñ¢ã¯ÿâœg§©Wðmh„Ã€/m}‘øá	 ò“*˜Û@9,cì)– &½LÀ§M˜Bü' 	Ÿ1azà§&,ÁÒhÂ2t¶B9nÂeðù#.‡FÚeÂÐH wÁ)¸NÃ8‡á,¨ÐÐ	½ Â8Ä`TŽuNA¨ƒ“°T8Ãã$ìãÏ‡á8uÍHgøÝ8à4œƒ°ÚÌ~;9ÞYÞ¢ÂÜ98gá4Ü*l‡y8 ‡à898]Ðü·avÂôó‘ÖŽ³~”í¼i”÷6³zS¯ó»à$çNi-¿éüÈ«ƒœ“'8^iÄa8ûà°9Î>“s%ÎNÃ88Þ^ØGà$THAŽ­Â9.ö›TMAŽ?1°ŽÀUzK˜ópœáë8LÌY8G¸œ×~„¯ÛÏðpn”ìY8}Ðíp/ÿ5¤Ú'ùL·ÃÈ­b˜v´ø4Üò?”ÑMöÂ$Œ€þæ!£`‡N0h…°¶À"¤ 	sPã°f`CÔœPà†;! =€ÔÃeh€.pAt@l Ü»¡	à‹0QxÚ¡tA-l„Ax?ÔÀ4l‚Aø`–…¿^€¿¶ÜsòHGW¨W¿ël`ò%øæ|:OÈ‡2Œÿís*–Ø‹ SƒÝM2´â]´*#Î‰ÃÖ­â«Ç"ÛÌ‡»é"—i§Ü(ñ‡•±¯ºr>d¨ê!ÛC Ê[óàˆ}•ÿuéŸ¾Œ'P#ù&òè\šEMãýþ‘|Þ¿dãŒd<ùf|´b}ˆ}tßB©ŸëWÝA·Ó¸ÜOòFI®j}‰?ÀÄ'òFž“öË0‚ïþ_Ï”È 
+endstream
+endobj
+306 0 obj
+<</Length 13/Filter/FlateDecode>>
+stream
+xœûÿþ  è÷
+endstream
+endobj
+307 0 obj
+<</Length 567/Type/CMap/Filter/FlateDecode/WMode 0>>
+stream
+xœm”Ënâ@E÷þŠš…%²`è‡„`‰E
+ÑÌÜc	Ú–þ~ä¾‰F³ÑéªêªÓv;þñ¾/]uà±ý©èƒÛªo
+¯^öuÇëªè/ì»WfÇîmgT7UÑrG«ízëË.Šã­/Î½ã[ÎÿRžùTú¯„¡­ú¶«.Q–Ý™g4Â…™hëØwew%õÅñ/nÚ²ò3ÒQo¼[U—a¸6šHš¼7U±ãŽŽ¥wt¢ÃÐ7Ò†\YtBá·¸ìëP¼»¶_¶þX‘E–ëkÉ$"š|ð©l»æJ£0Ø9>"òÖ8nJ¢ÑmØoÁ]_×g†$VÙ»ð2È¿î/L¾¯Š%é¯¥ÏkÍ²Áä÷Kån 1bQ9në}ÁÍÞŸ8š+¥Ô‚æyžç‹¡ã?ñTÊÇâÏ¾	ézAs¥’Õ"	4}YÐ”ÊPŠX
+š‚$–2
+ôˆXzm@KìiAÏ ©[h=¥n(•º{"S T¿“iñÓ ñƒ»†_’Äo
+‚Ÿ•ð³˜SÃÏJ&üRœ‹?‰Á/‘îðK¥ü¬Äà—ÀO‹ÈÀ/ÁIy~xFFüAðË0‹Ÿ‘Lø%˜ÌÀÏH<?œ _
+w¿Dö„Ÿ‚Ÿ•9á7…Ÿ_¶‰Ÿt€ŸEÌÂÏb?‹L¿LbðKUxÕå^úánßoYÑ7û.\íp¥†ûSz¾#êªªÂ_ø¸Ü¾S½å‚àR
+endstream
+endobj
+308 0 obj
+<</Length 7879/Filter/FlateDecode>>
+stream
+xœ­{	p[Ç™æ×ý.I€8x€ÇŠÄ/I€·HñÐñ ËÀCm]–%K>2–c;Q˜Ä›‰g2“Lœ©Í½Iª!%¶ÌÝÙd½UN¶’ÊÔnœlM6“ÔxjS»“MíZ›dg-r«ßhR‡íL­`¾þ_÷ßwÿ÷ß€A ”à*t,?vQ-;¬½à_øÆ‰ó'Ï|®×û@Než“§?ñÖ§ÿO ü9 á§V³+ÎÞä?íÝ zOZÍ—?´ŸÐtêÌÅ+O~¾ôS@û' üäô¹åìßnüD:N8{&{å¼ðQÇe ã' Ô³Ù3«©ÇV~tü ÿãü¹G/J¯|èe òK /œ¿°z~ÿ«O„î+ ~ßÿß~ìG
+)ºPØê£¯oÝ¢Ž­[[:ª¬·nñ?$@/zéëäAþ·kî›Ô¶=ûÍüü½Ø‹ôG ryëïtƒLÒïÀ «Ñ´ªNßDÙü4“¬ÛÇö¤3'Ôõƒ£ì«E(Âò²¶äóûÒI-uÉL"ÌˆÎÔÌ‰0£ºæ×üa&èêÊÁíA"É\I5“Iä¨;™È„$£ÉWTf×M&³+Lœ»rRšÌ$˜µÖÏ{¯—yH¢Ve4©%®»ˆ+™IhsÆjúº—pÌ0u&„˜'iðõ˜7™Ì#øÔ•}gŽ‰Á#×÷Òäèò(“G?é…¿æ÷­*››3ü,žö©¬C}é´š³°³+lÏœáÏ¿©¬ƒwpÌïÌê	u}=«2Ûœ‘ñ©Låc6õr¨7ãË¤Ói£fO.3,ÓÙÏìIß4«çPýtö¦Ëã¦„¥tz%›f$”NçOVW˜7©%Òa&éê¨ÊÄ@vEeJrÎ`Š–`EZÂç÷§É„™l²›	!u%§,%T>Èë³¶ÏŸLÎŒ.3©Õ¯²¢¤º®®3ÊuH&çÌœ/»6´´?­²ø¢ÁHÈÇù’ßJ˜):+N†®ƒZb.ÒY±–ÐT-‘eté#ËŒd˜ÒfÅºÊw[–\¾)bIåX<“æ(™”¹[›~½¸ÉÑD«[qJôÝŠd·¨Ædb £Ž®kY.T“Ùðq0ÕÇâÛcB@Ë¦¬%Jï35Í|rü^“Ê¸þk‰¥v£s†ß§ùÓ­þ0+×s”Ž²•l*Ì:#UeåÉ)N@eåZ"ÍümÁP™Ã”—SW™ÃdŠzSÄòº–eÎdF]Ï¨Ì©%´0«Ð§9q%•nb¥«Ú•0séÓóÆô¢Õéó§›˜Ëìwë9T$¹ŠŠ$#Ùs†¸É1HäÊùÃA	F¼šÊ„Àœ‘ãìcb ±¾®òe­~‘löYã|
+˜=iVžgŽäx†ÑÝÂºs€KK1’d¾N1¥åÑ‘=`°
+-¡Ž²2-ÁJ5&g*sk	5ÃHö•ª*'\H$œîd†åÜE!öÑ¯1f^=O(Ì*õám•ž£¼­ÖsokôœÈ[Ÿž“x[«çdÞÖé9…·õz®ˆ·z®˜·!]+‚É™é†¦¶1ò 7›0Ówz·±Ã;ƒÛƒ¬AU+ÝïÀü¬ß²ÎÊºó|~=5fzŽðVÓs”·MzNàm@Ï‰¼ê9‰·ÍzNæí=§ð¶EÏñ¶UÏó¶MWMÍm×Õ«Ê¨I‘WŽ,·Æ6®¼:k±öÖ0ëÔUu\½XµlŸÆ=ü»bøøé»
+²Î•É£\õXgkN"žQ£#mž2²ƒ=÷ÃéÖÕsç=:ò8£w¯ÉHèž{áýð~Ó™©a­/×M<ü¬½º:¨ŽßgÿÉl_˜Eõ¶ÊÁ0ë{/TF’Ë}aÖ¯ç(¼µMç¾ÑÀäúú¸6®eUcÉÇÝ¯–¸ÞGˆÇÝf:ƒ—Uj	&˜0Ñrv$XI2´ºÞ¦©êàz_˜Åv£©m=&k‰¶Ê2Ü¹Äç¢*©¾bPªI'¸Ëµ%ÕuÍœ¡e˜œ¼Ón3ÜíYáILfV4&%³+s“Y“’îòîœ“ÕT•‰Am,ÛçÓ˜-9ÆC—-i®’Qïµˆf9W9™áÂY&ÝE•‰A¾‰ ß„È¬ä]ê;k¥Ãl°ÀUU™ÌóBì³¡í!f3ÇÇ´q¾(—âð6ùa,N30ÚÔAÍoÞ|§Ê÷•“L
+LîLb,!ÞKÛóÒÒ¸ÊïÝ±“dA\žéÜyä‚ˆãº¦¶q.Ž±Ê¤1ç[Hê`º-×AÜ¡0Ù5ºà›Û5š¸çÜw›‘ÔÙ@èÝLé,ZWÕA®cë}÷Ger²u„ÂlÔ<2×Ï Åù,³k	ëè\A5uPmÓúòôÇôœM$
+S~O•ÿÿ¥ÅüLÜj}>ÿ}ñ§óû×s¸2¡çù¹ÌøFó§ÙfÁ¤Îà±Ìþ:¸…»ÚXok˜MÝ§ZÏ¸],ÚfûtÖßf3œ‹£šÚ¦Ž­kÙ·fu®Ðl&fûõëÀX(Ìæôë ˜×¯³gA¿NÌžEŽ3
+³‡9qÖo H†ÂÌÐoð*fiý±úŽè7ˆÕ÷ Ç#:ÊñLèAŽgBÇ8ž	çkŽ†Â,Ã×ä@–¯É%¾&–9ÎD(ÌV8V9Npœ4÷•
+…Ù)s_Z3÷Å¡‡Ì}qèas_:mî‹CgÌ}qè¬¹/ÓsÜàyóÅCaöˆŽ„Âìgºù–…Ù£zŽäq.Z Ç¹dâ<ÎczCÛT/›oæŒ+Èg<ný	=GòOZ GxÊ9Âô†·éýùf¢?mýªrôgôÉ#|Ð9Â³ÈžÓsØ»MïyóÍDÿrô[ G¿¦çHá#ÈÖ-#|T¿^b¦¸Lö]©0jh~Ÿ?N„XÑ*šæ®‚u˜‡X
+ }‚´Äƒ¼O =)á°HÈ~QQ©p:$¹:äò;ý§ß©ÒªÛ¿$?ÝÌö·oÒ?º} ˜Èoé$4ÄkÄf@Í„ÒA:@‚ätŠ¶ªPÄüÊì¥ùSdÚN7n¿0­-Ä RAß@#zÌ=vÿ!§:Ôn|%^RL© UQ ûÌò+^£IB–
+Ï@ÄãE2ÅAqÖ7ÍìsF¼|„£‘,åJw–û=è¼‰t:·{š<-~O ÉQlk¹"J¤·7Òå­´[Q"ŠÖìéŽF{{ºƒZ£"ËŠ ¹z{ºðg<’o:Ú3$Ë5³ýñ„Ò5Y:Ñ 	r°¥­¥R“fâòDçžš <0CÅ±è`ï@ßTJÕþoª®¶¨ü×õÕ­­-•›?'Ãõµ{j&ÔÍŸƒópdëynÀ‹®x{…ÓQ.J û@ilF$ 9.B†gd"I	‰KÊÓétz›/äå»viÑH4Â!TF+YÖ>ß,>Yòdí|Ã×K¾w?Ý\>›¬³›*ähòå—“›´ÏuÙº5.ÉÉ­[ÔM¨B#†â7¥„ìƒBE²f±ž{•P*de"	a¶º¨n¬ö×Õ¢
+•Mî@‘­ÚÜLž¥²"{ÜÞHWo´R–5*+J¯ÉÚëk“Ï,Ìfÿì¿èTï¾p4üÈ~i©„|õJgýÜÙ£ŸœŸLŒed[i|:²·qj’üÍ1Ã&ímoY–Ñ·u‹NÒ7áB_ÿV‘D’×µZP:4Q$YîÐLv!+ ‚¶©wà@óˆ(à¹ß“Ö{“á:Wæv»ƒî@‹ÓÐ¸ š,›:–W=WDÐ‚ÑÞ‚ÆÉŠÅ0ò¢ ™]ì<{°Ö!ôÌ>5;i+qÑDï„a·‹}=O$R'–f^z¨»‹Ü®íï$/”É¡®ÃÓUžXñ­[´Š:PŠèñPš—ŸÄGV$„$ÈlYPÖPV_éA)ìÙV¹K|²Ö{×Þ¾|jüÉ}K§ÆŸÚ7.µI‰Áq«±_^Î¼¸ÿ±•Ì‹ûSÆì`½'¾7ß˜ú¨B¨Æµo	„
+‰¹ ÈÂÍW©é‡ò‚ª4m|»&‡w»ï7ó¾“¸4JT£:àirÊ¶îâò>ÀãÎºiõŠ;4ëëc#Ór÷lD
+…†::mT|bdtÿ˜ªm~tÖW·w÷nþ:¶nQu`Úâ¡J¯@EPÓvªYî°·Ü=h„’i*ÍQ/·žî`sssž«…äüö¸½••õÔã–µ×Î74Ì÷§ö77Mø@&‘­:Çc‰±–æÉð°þô){W{[s°§Í_/•ØúGöl	vT7u†ke»âíiŸ{Ûk«ªÔaÚÍ7^vPºÓpD±ÀL®Ä4JœqáÃ1Y»Ë îÄs¿'­÷&³Ãpö¸Mn8;DeZP³&hØÖM¥ œuï²œÎY2eÌXÞ~¨øŽélþŒ¼ÅÈÔÕ~€¼AE8Ðoˆ`	Ç­#qAš‚tÀáorrAT‰G™kPÿ¡ÙJ©Î›-5Â±ªN[˜ŠëÉñÙj_ßÐæ[|oä0ž…€ê¸—G,0È#4NÁV
+(Z”ö~Ðûì³Ïò9Õ[·è8}-\Ïª*ïÐ³‘;õ¬{úýôìNEóZœ½ñ„:ì7†2‘ØôÂÌÞS©¬?0°ïpt`òÀÔÈãsöDg¤kRï.uº¤âÇºövëzx|¨­«Ôé>H¬ös]ëÙºEÕ¼¾K×€;+Íò$±mû\Iîé]-MÙvïNë½ÉÜ[×„;tMÑšîÖµÜìÀ.]+Ÿ%Íéº6ÒKßÜüâ¶²éß¥jz'e¾-6Púâ=ED <¿!tŸH(µüØä²•²|çcfô×Ðèx‚fPñ6GÍ-—¨+"X7ÚkÂ²v ¿7”ž\,uõ‹ƒ#ûä®ÙNI7ÝZxöë™Õ7Æ»{§MÿVµ‡è›SWiú7Rvûí³'@p ¡Pà×‹%„7³“m­U 8¦5AsiQ¿B^\[Xûov´Ó·_ &&Þ‰ßZÞ±—ËÉÝ¨6eeepVÒ!tgôöÃäËs‘*w‡ïw¡ô>ˆp½p»Ý ×ŒúZ¸àršxzãÞÃ£á^!üéÝž¨|öÐ‹÷áGn¿}WÏÇLüŽ¾‰Rî‡Šˆ™2ÄS0ç‰È f	ì6EF))mÞP¤ ~;QžilÎÌœ-*m¬+.§¿}^´§@ØºEèëÐpýåò2*Ñ÷ë!A$ñäŸÂƒ¬¼+j¼–,Z¨»dð^ôÞ).	›Óé
+x
+Uwg
+e¹0“é–D#‚F¾ ù§‡Óôì¢q¤tÊÞÛ¿¸ìrÈO¤ÒöâO–ü¬ß‰hìêSK?ùì‘TU÷ÀSç3Má/›èMl~™ó}ëÕ-üwú&|ˆÆ»%QdžŠ‚©ñC3’™óŠW²<&sõ÷¡ÆYá×œ•E¶Zîp›£•VJžfyÁMqdxÀÑs¦béBÉ…Šâdß“%—ƒÅ\òÇµµ¾Ñ5êê¸(ÒéäÃ=ñd×ÃÉÛo´˜ºPÐfú:jŒkŽr*XÊ`ú1‹«ùøámjuˆ¶šßÓm­l.däŠŸüj³£ŒØûcµŠ02›­™˜øÚƒ[ú;réàÂƒý-e±x_í¿XšÛÿ¡©op›0œ×™øÐ‚T|$Poš-Ä""	¢´VÈ0Gf3Ã”­³¶Önj[j÷h~»Ï^ã®@	lMÅ<Ó´d¸3ÏÜe/×ã|j&kÃýë¾Þ¿þèÁ.åûÍ§Ý'ÕùÄ¢aû¯Ö~ö9þ7ñÄÙ­{>e=ÿ«Û)VEÌ÷9C[·h%Ý€ôÆ#6"
+œD"¬™•°LD‘f%+tx½€7àmª¯…î W±Uå3ãhD–•Ê]rÇ¦ááÔÒŸÎŸ½öéN©)[\NþÁââƒv1±wÜ|ÚYY}í3‡ÿü"mïY:0öøäØìD•£ÈzZ1×bst•Û¾Öt³tÉŠY *Íj‹ûZWÞÓ÷šž¾ŒæÀ?$Ë;÷îMÖ•/¤\KéSG+öÒÍóG´¾þŽƒóäË›k~`o:Ýyš\6×LlýŽÖQ*Ž·B)áa¨˜Ð)®fÇyHæ»H˜Î¾•ž6~O@„ÊaÚÓÝ-DK«%JªtîB¬vÚìÏ6‹ÝgK¨¸9P\rl}f"êÝ»p2·l,­"G“fLØú-@f|)á;€	'!Šù8#s>’Y ÄV\”6
+wÈ<>“ˆKÐ„Ù¨þÍQƒLÍþEñŸýÕw¿K7nÑ›_µøzÝ€‹óÕQ,È>ó>!VÈêÜN·Ç!™I€«2ârñÿH„hB³F´óóÅ²ø‘?È”—‰6¿û`…MÚü_ÇèÆæçÞ"1R³ùŸ7DÜ#ç~}û/@Ð
+Ðbº~#K|9Óhc3” BæL²%N•IF#.MiŽF„ˆÒjÿÞñ¢ï·üøÙµWí´ûó=_ç×0³[·è}µ<¬®*.ó¡!o€f‰þNX_s ÉÌïá5·ËóÙ¾¼åÂŠËQ”ë„IÛß.xÊ'Ïg:öLÞç7Ò ˜ÞºE‹©õ|¾[ñ®}¤îÜG=êšù|ô>±vÂVÇŸš1Ê“åý]‰Å2›”ðµ6÷EÎÌò*ó“s©¾š¶¦Cóƒõñg´×¿ÈÉ4¦Ý” .^#Îmÿc3ùXét9+¸kti‚æŠð ý­²ºïÒåçÍ'=rû‹tãöé‘ÛcœÞA@ØO7PÎoËŠ"Ü‹¢‡S$Dà	'I"‚æ¢¿ùƒ“!éÒÜÇÖ®
+ÄùÈÇæ.Ó©Í£¤ýâíWèÆæóäÉÛctêºøMTóOÍÂØÊY·+Xž	ÒYwÀÓ”×LáÞU«öÊìÀÝUë,ÏBï]·.nÝ2sÏj\¶â…uÉÄ]ù’¸+æ{ó#¢8hïŠó÷šw¿)étú§;àÑøY÷KY5òÏîq”C³f†êo$}›•?	©»ý6^"
+ù÷$õq¸æ:qœ²GQåŠú•—ÊH}Q,¿ÐÐ#tÅæ=+… Rá$'ÁCjlF"æ"€bó;7ëòÀ¯˜¡ýyÙ¾ùÙ=dÜ¾ùjÝ˜øÕÄæ¿3éþpë1š ¿ƒÁiV5gÄK@@>ÄåËTÌqž!¥¿Yí¢¶ªPE>¼˜æP©ƒ=?œ{núàÃŸu—ÉGgFæÉø¿Ú5ùã+›‚+ßˆEÿÕys–­ÇÈK»×Á‡x®HÌuÈó ¶×,+ÛW;Í¯×C^ºc¡æ»¢&Ÿ&èJQ#Ó¬yÎˆû~ûF!Ñ5È2¿~Ç8Ì<[EzA!Dð4ïNœtÜQ^Vå-«.¯v:Ý~G‘ÍŠh®|®Â5Ê³:SÉ5á™…Kÿçà¡sËO§/_¸Ù*’…HÛWBtÃØwêqeó?’ÐX¤£©ÂÓÒº¹U«åÚãúÝr…(JÇyI5(|0ÿÇKªmé*~¥ýùš}ó‹{È~ûf®…µÓ‰˜øYËXw?1ºFDâjƒÓA%§E¢@DžYHÇ!I1nÐ…¢Óš²­6Düw”šV™þNÖæòÓöÍïÈ£W÷>yxz­v¬&>0~¤DLÄÃÃjÊ OÐG7ß
+–Ç¯L¦"mímÓ©*wßP}]1¹jí±jëÒ×æy[‰‚¸‰µŠ’°çâ’éäŽlR…,L·M ·65ÖùÊK‹„IX±yCd{ƒJóöE¯â½ç´(	Œ´‰ÃÝÙx´å¡cÍ˜%ÑÑ‘'æl}ª252qØ&&“‹vò‡ÃQ¯­¥ãH{ÏÐüTrµB,žNöµ¶uŒ×”t÷qlØÒÍÚ±øQÜî-¢²”/™-ÖˆÂ@j¦ˆÈ²éEÍúYÌ*DÇ¶¿vB†gLt¼;¶û}Ò}¿$yMã©¯ê;êÛ÷Q‡Zw ¨Ûjî.æß©2eY«¸»Ð4xe?±XæŒ‘ý‹]góå¦ë™ÕµH[‰ƒ&zÇÓöb)ÚË‹ü©O%R«Ç§þä„Ywž=Aêû#‰%^zšê­/±t&²õÚNàçq‡W¡”4Ô×Õú¨Zà´fŽˆ« ÄŠó©Y¢–í[,nØFÅaþ]“©W»ÐÜïM©êýPŠk÷ÁàeQá{“´yß €&VÑäæÆ.67+ü¦ÍºÓò—°•ÑhD!R´9ZÉ5[#ÏÝlûKÈ‰ØL]OS|~ºåpÌÍ{6?ƒ­’†~GMoØæ³d²¾z¤Ï~àU³‹{÷mÞŒ•\sïÙÛ¢E,Þ& ÂóBóîÏtE<©0sÛí0Å““Ä¥…K<ƒåß¼ñûÂOS'Q
+¥HPœ#ä&yõ„øÌ–|æC1nën™ò2G!DIwÔhEæ7eùM×kk=¦twÕ†j[›y5«›5×ÀhtûÊp§©WÜQùÜùþ©3GH[Wìâþc'ö“þØÈÓÆµÅ"!KšO÷Q›4™œ1Ÿöc³S§½EŽñÎîû&†V+‹Ó#ƒ+1òÒP¤¢<Üi=7¿’¬/D­'÷ü^ª“¾nÖuíq]1ë:‰ˆÜ“µ‚Ó5ïFyqìåE]K èâ1¼›wššG¾ã´séOçÏ]ût—0¬‚îØ©³£¤#Û]Ð=²ò…]%²u‹ÎSF0õtkÝ.©ÙWA„6³½ü÷–ÜOÈÅ„™sŒ ®·õ–íïù¢…\Ù¼ÌUšùC—×ã)Ô¤Š’ß¾u±k}ØöðcöuJ“¢»*´WUŠË?×hIÖuÕ)îù¡®í"[ùù»"©š@S±Çšä†š vìÃuS.%ÛÞYï?4SFŽŠªZa¨~Â­œjéþÎñ~rôÐŽ|Á/Bñ=Àó[^ÓmgVùï½îÒØ`kòËÖwÏ¦¦išà2}¡JÚyð¿r†u-:bÅ~úÏ`ó¯É#=mfàçöE$úy†¾Í9y%¯åI ÈáÂ5;ÁÎ„0'#E¸ý?SñP}ã¡‡¶ïÞ~NEpÅÖ7¦‰:<âê'æŒ*Þ~Ûú9ÿÍ<n~ç_þôxùàÿ†"ðß§ã?Ù?ÁÇŽŸŒý[C[ŠxM<
+…ãæ‰dóW€È¶†6 ^~‰/íú}z/5 R³DGLxÃä5ŒP“Ô@5 j NÄ¨jÀE^C?5ðmj šè¡|ÔÀaŽÏiP	òÚÖ«Ô@50Låé%¨±õ[á9œ§ZùšÔÀ45Ð,<‡ƒù5©—¨vjà‡Ô@KnÏ¯_E4P¢szæ>Zòë+‘ø> ´b
+ñ[%§´ž¤?Z„¿~-‹ÇÅ·¤qéŒLä°ü—Š¢Œ+_RnE‹.}¥èÅ¥ÅóÅŸ.þ·ÅoÙ:mbû–í%ž’É’^ò#{ÀþÑÒ½¥¿*SÊªË^,ûûòlùKåß.ÿë¼Œzñ}4âaÈ ø&	âã ùe™D3\çZ*øŒ©#&â3y˜ÂŽïäa)ü ‹è&Ž<,¡†¤ò°Œ6r,aŽ|,ãùi.A#Mäa»	'qçñ8.`'q
+¡¢èD*&‘ÀTëÎ£*²8‹sì,N˜ýgÅE¬áÎBÅ.`§°†‹XÅ2.âÑ<ö²9§qêŽùø¬âQ¬âÃ*VÐ†5Œ@ÅaSº ó¸d®up*1‰‹Èâ4Ö°Œ.´¡ÃüÄpÓ8ŒYÄL:;©ì¦±ˆð.ïoUu×œC&Þ£Ûxg¿ßÚ	œÃi“·3&¥dñ8Tÿ‰ÜžÁÆª‰µ„%¬á,†sÈâ’)…ÇLyªXÉŸu²f…µ†Õm.0pš»8Uœ5%xç1€v´ã²ùáÒË¢gÍù¦¿ÚúÍUl}ƒ÷ü?cz´cæp‡€ÌãqNôbGE
+ûÑŠIxàB5úFàFcèD¦aÀ”ÀŽìA¼˜ÂƒÐQjñ "ø)¸}NßÄ÷Œ!/¤±~-z>%ñ
+ê	7Éhåoñ²yqRì/ê[DŸ"Ûòé‘{h˜6JfgiâÛî«WË®Ú¯Ú®*€Œ’Ö\‰o#¾ãÃ{_… ¤rMäÚ¼Áâ×þ¾’Êíáï7‹`u •öåšy×FÑU1~mù@aÀJ+é4É¢u’\Öz“l=ÏÄç(R7¤©€ÿD¨
+endstream
+endobj
+309 0 obj
+<</Length 1249/Filter/FlateDecode>>
+stream
+xœµWMo7½ï¯`Û’C¸ü)	0ÄNŠ6h€Y ‡$gbÇf×‰³=ôßÔh6»öºPô²š7¢(òñ‰ÚY>½Ù~º<¶púòlñÇ«À°^ÃW ¬©W'óâ’-=e²
+_‡M[¸g‚±áaìžÆÅÕârñjñüåÙrÞóädùt»=®.>¼Y®®?¿[¾þóýö¯ÏË_.Î?\Ü,WñüûùÇO›óí§ëÍ“'§ÏÎš‡×ŸÏ7''Ë—g¿>š^,à5ÁÄ¦§qzâ„¬j06‹Z\-þXl_€PÌ¹d·)ù=Ü]îÑÀRsÎñ81Â‡`$Y#"±!	¬°­Šªjq¬\¦²CÎH
+Ã‹¢•y!³ åÙkG$©(e7«	ÃÔ±˜Ü(£‡¥ÒGHNX˜Ù !;TÂœæ=&0€fÅ”:Tg`rÌ>ƒ]Ü
+ê´ÈA”0ëŽ‹	m;ý6ëŒ‰A„1$W®ŒÔ2Ô‚¼Ã#$µHK(a©”Ðk§µm3s<,®À,#gFrXƒYÅ
+\+¦
+cƒº™0)TÁ*I¹"×ÛP¤`Õ°&Å¢w0¡O˜[¡DbÙ„]÷°QlÛÖ‡F­ppqÇöQ®)“ŽWà©¢;pNH.çX×ñ8ã`)HóÌA¢PÆîŽA`ÁÌàfèeF¸6™Ì³’°e%8ŸQÔËÂ¶cÑ\SSb.à¦Q®ŽðLXe7›-lsm±æ¬2 “ óŒGÈÄPkdî¥†ÌCŠn‚e83VëÐÂ¾ë4ïPH>Ý±pjYÅÙ±IŒ	Ü<TG¸FçÙ’šp¥Ä™Œ@%„¡.l‚hEÊwqi*£Ô8Åâ(®K %¶KÆZ€š¬Š¡' à¢á‹` NSnm–“aë[œK´äœ$gë$!U0IÀ­‚åÖ \â˜Xðçy:ÌÔ$R‘£C«TR*kêâC¦Â$<ZÉ,T#"Aì ÌÑA©¢–Ø˜%²ÑxÍÀl2GÉ˜skwŠôjk8Ñ¾Y›¢æ†4Pë/á×j¤›-|‰¥p1‚äŠ›ø¤Hk©„¤$e”£ÞRK1)¦¸·¤V4êM1Õ±´ÎÈSé¸ÕNZ³‰€ˆ8r†5j+ÈÃO‘IŽ)@²CIÑüài²jÄ.D!êv¤¼!+-½|V.M$jŸÃÑÁöC»e_Ý¹%y¾%w7|0-h¥ÚÁW’²fk‘´
+[ÜuïÄÚ·8]ÁêfyI V—ûÿVë7ßÑ["î£ôQû˜úh}ô>æ6¾o¿ÛÛÍ„X÷ÐåÅM·˜}õ‘'Ÿ$tt¯Ý{é±ŠÜò“½[½X<_áTŽqšª¡$û¿8=ŒÎgÎcŽ[:ÇÒ9ßã–„îÏJ—¿o>>¼Ø<:š^r,þ_$Ãrz½¤Ò“Ó¹h=å£IíHP9L~GÒ÷ŠˆTŠêÙšní7|Ž»Ç§;u<‹®½‡CåÝáþ¥;¥‰~˜ŽWç_ÿ±~ou6÷ñ÷Ã~Y~<àªnfdbrÎ|Öj£ï§ýÚ=¸UÈfÙ·9<ÂY:úmqz½Ý^¯¿}^ü|}½ý‡Ï‹¿çêÖ2
+endstream
+endobj
+310 0 obj
+<</Length 2054/Filter/FlateDecode>>
+stream
+xœÝZÝ·×_1I‹/Gœá7`ˆ/)Ò"Zœ€>Äy8+§Ø…Nç(
+Šü÷Á¬´«%—\éî$£è‹–¤–ä|üæ‹Üé×ëÍûÅÍ|¯^_M~
+^ÈÃG†ùÝt®`þ(Œ&*ŠNZÖÇÞJÓ¯l„ßæ«fâ8bP°lž²Âr·Òròn²˜ükòíë«i»çË—Ó¯7››ù»ÛŸœÎî?ü4½þýíæ·Óïno~¾]OgÒþçÍ/ïW7›÷÷«¯¾zõiYaÐZƒ7îÀÕ´–Û7­îéNÞMþ=YM~…ÊRlÝ–Ï®ïÓE{|GCä½4·" †q±ç	m,‚; 1è ŒÚÁ(xŒ>€¬,:@ÌÒšÆI{	d,:Ó¼a4i¡2Œ’ƒ9°AX‹^ËœˆVº^ ‡&pŒd1š Î£Ò0þc V‰`)ü›ÈÁ˜ÀÀdP;í:Š*P–umð,z€™1’ÐKƒ ZEÔA ÆÀ´üA@d‘ä"ôˆ<Zßu…ßˆ^wK K²S7ÁjÔnÛÕÒµ¨h»ºÂ¾·Í‚lzK`Ñk–QÆ£ØôXD-ôƒdd~è} R€”cDK¢CÏÀÑažBj´ëÔV»óÉ»-õ²;$wz¹:Y-pÓ#e¤'/‹(‚A„õÝßQ+¬€XctMWø†ƒZ´
+@Á!Åf²þÈËj!óÆÂ¶6výáfõòåôõÕß¿ÕNgÝžÁ…€Ê$HF“ö²Ò‘É
+èYÆØ6HŸ¼š‚ÙzºPÀ
+f‹¾¿P0»ûñù¥ÔgòóFiÞ>•kžo·=Þö”2»'ÉóÓÒ«ÚÊób÷W³¤‹p3ø—]§]±}êl¼$mõF‘«®}šÚé6]Fù­›þ»Ÿ÷9k)ïèy~ùÓì“ogCgØ¸»ïoþ¸ÿ}SÖ˜Úkìêºñ'V¼“´Õ±¸ç`7åáúêPhá¿`àõÎ=ïœÌäº *nj-:÷hœWqRÑCd¾Ú)s;sÑü®û
+~£È—WoÐïÞcêc¡¸æ"£«]1_É$Ð·ÙÛ)WŠ}™^ÎûTzeÞ:¥U™ŠÎL
+’¬í\á Ÿ•Œî÷O¡E.BQ[!œŠ‹„ÔÄœ; ìE”)jŠÍQjÚ¼a¶™P+ëÞjiä"×É®)Ýù¾ú5Wnÿß8YŒJ±•x‰†qI<û€Ò²”n¥…üîrÒÂ×ª.•ñ™|æÎ‹,R–rßÖ±t*ßvP½‰ßèö€ê€¨ÐØ{™˜™ÚÇLøm6C÷3Œa¼ÙE“}„0pÆv¾=fnŠX­œ:S¦)AÓF‡Z»3AS÷YÚ”@•ˆ¬‰‡K<V—da+_“®}Òålm>Øìü¬ù¬ëö|’/{˜šÇoŸªRÛºlQÆ¡öî%û~RÖ¾›&bÛÞâ±¹®Õ¡' 3$»®¸+-Ñ=àX–8VÜÐzT—™“Ú=ßŽå›Il¸-ÝîœQÅÅP´£±µ³‘¹à à|úƒeD’ké”Ojë~Ä— k¢AæsvÝÛä9’L^”Âëç™˜Ò¤¹’íØó²«Þ9¸Ë8ýl%_ôo%ŸcµÕYž]'œüU~¾”ŸýaLÄ–¦6—ciÐ´‹_Ónùa¡6îCÊkŒ!*å9¨:¢.3öŠ[Ë]‚>Æ¡dùÎ>÷ÉÄ'Uh–Ü¬þ{d•1”•åã^½dL{üpÉçdž´—æ_TÊØä ±1kÐù3•G¹f\&ÍÔY¥õwÿÖEyeZX)×õ²›³ªTµGV¯yÜœ Ô(kãXËIJñº"¡J$dÈ9u¥ÃŸcÎ9êU%ÉæádŽT<	7Ú`ˆgª‰Ò*hŸ¤YyVÐ>P2c> æ“²¸÷äP?8tOa“¥ŽÝ[vô¤p¤¬"š~³úåùíê²¨SåQ?ÚÅ¨1•öËÈ.’µÜÚÞ•Bjwù%…ïf¶´ÓåûÅR-·`&Iµ—+Z)•ž]®4‡£€Ü0ýååì?Jt]Áb‘¨“éâ‹NÜ]¾ÓP[H;»ÌÎ–k‚Öëæ™_ßÆš=Ç´2<sae1<U‡ŠË¼˜?Eð;YÚ®—ûò´6ª¥„ÝÕÅˆÌ‹,ZnÆ]ø¸–àYÂ¨óYBvÂÔ·/NnØ¯úÔQ¶2,hÙØÊÓ¤t”­Pøy¦sèz®K|óR#}ù±uíX8“tr¶vlÖoJCr¢zñ”ävD‘¡‚vm1Æó¦ùÅ«¤ýHÅÙäþ±Kˆ³ô+;,Íª×ô¾£Û³´”sRã§¥}§MèSì|ŒäöÈ´ÿAˆÄ’C–Ï«>þsé¨°ê@ T×àú´xÙºÇÇÈý|±âÈ˜Fž=æòHÐètHÓÉBî´Ö·…@ëj¶ýìÒ)·€-†Ÿõ¡‡’M}É‘øÊÃ
+Ycx¢DŽ
+¯ù1|îOóCÕÜ_ç5n|ÔG¦ÓÏ£fõP{£vœV»éµÉøüEê
+²=£9×—YmTKýQâõ«ßÕÒ"[ÒÓÅé”Õü<«Þ8î?5~u¿ÙÜßí¿6þÛýý¦þµqrA¨Ð¾Oø^ºŒä[ÝG:ÑxÄ%äÿË×t—ª{B´Ú ;·^¿‹þãú)
+endstream
+endobj
+311 0 obj
+<</Length 2376/Filter/FlateDecode>>
+stream
+xœÕ[Ýs#·×_fÚ«Ýˆ ¿[çÒœ“LÛÉuÚ±gúËƒ­Ø¹ëÈòÅQ¦“ÿ¾Ã•v½Ä’«µ,¹í‹v¹Z’ ø€Øùçë·W‹5¼y{>û(ø}ºøÈ°¸›/,~…ÑDEÑ¥;ë‚coÓ­3^Ù?.VMÇ;pÄ `Ù\ÓËíHËÙûÙíì³/ßžÏÛ9ÏÎæŸ¯×W‹÷7ß}3¿¼ÿøíüâ§ëõÏoæ¾¹úîæa~™îÿ~õý‡ÕÕúÃýêõë7_$"-+Zkð&ÂX£š»åæŽ›»î•Ôœ½Ÿýs¶šý 
+•3¤ØºŸ]Ûçƒöø&Ž†Èût»5Œ'ÛpÎ‘ÐÆ Áb ¸
+ƒÀ¨,‚Çè¤ñ‚E§(  ‘9Ý-€ŒGãÒýÈXt¦yÃhéa¤€,€ªÀZô:õ‰hSÓ'È¡‰#YŒ&€ó¨4,ÿ1 «ˆD°Lü›ÈÁ˜ÀÀdP;í:Š*PNãÚàXô* 3c¤D/%Ð*¢‰ b@§?ˆ,RúŸ½"ÖwÍÄoD¯»K Ki¦®ƒÕ¨Ý¦©SÓ¢¢Íè6&ö½mdkÐXûˆ>±fÓóÀèB 6½N¢NôƒdRÿÐû ¤4šRŽ-ˆ=G‡!µR³ºNmV—a1{¿¡>MÆÉÃ…ž’\]-pÓ"eR+½œDšXßþub…•ÂàkŒ®i&¾Ã!	:=Ð* ‡›Î:ñG>&Y4¶Ñ±‹W«³³ùÛó¿|ªUœN»=ƒ•ÉŒ&í5(d¥#“M çôŒmƒôÙ›KPpù0¿UÀ
+.oûöBÁåÝ7'ï”Rï”²éúIúôóËÍcVÛ+m¯¼¹’Ûv3ù{Ýóí•|þû\ùiã³:ýöò¯³//‡†¨15__ý|ÿÓº,-õ(­ó‹F—m²é®'Ólc"<\œÿZø7x»5[Ÿ]–ˆŠ“Z‹Îí½FÄ#kÄ:âí¦¥M.B%EÈb©„¨»¥ðbœ¶=qüîÓ§®í­ZÚ³vºwŠsÔ\ç’ÀR;”VbH'³Yû!ë½Îú¶ÿy1¢db_QæBèDÕJa;š¶ùÛÚ½­L®)}¬r«ÚbáHXÕt¬ri”Žu]BÞ«Læ×É‹ÙÖNàûdõç~fN¤?ÌCb\’äÉ@[e£“vÆÆ¶µj#Ô*gö±Ý®UG¡<ÛQŠ«Öaª‹0%‡D|$˜¶ˆZ&2›2O?¿èî~ÛêeSbÁJûèöß»IW™ÈwÖïÔ‡¾æi*Ð­§Àvk†º­Ù÷üƒçîÿ¹Ê6Í4«ôÛ"¶LËk}!ìüë«Õ÷'7«ÓâŠXÁí*Þ*ªèº°n-øÊBi×/3d­.çº¸ÊäÒsÕ{²µJu™¹¢¨Ø!wýkù é@¥‹HmMºØ»]@ì
+Ò¨Øì§ÒYä|öõ¸µ|šÔùN5kù4^nKò|5iÊu&Z7â+å{äº8úfœSaZ‘•ÕCŒ4\¦:p}¸Ê¡¥ãì;6óñ]%ô:·Ù§;|.9+'Õ•Ýäv?ÄW0ZdUbj’?[tNÝŒÒ§E@÷GÈb§¹32p«ºY©¨žf(þÜÀ¾ÊP¥	½>N€x"pÐÚ’Fü§Bs×°¸ÔÂB´îDû”ÿ>Áå}U„ŒÙíbÅ¢\í&gÓ“«ö)Õ™büF¨.$±štã8Lk#Ðß^þ«L³4Áb‘–ƒ­qÜÊÇa¯Ú?œ-ðÓøCÕøåú‡GÍþ˜~ÎJZÎ#»Ú®¨æJ´Ë"3›¹:¡Ô1NT–NÙÛcC‡Û¼[Æ·½DªüçÅ\…!‹F¹—Uo]Yƒ!-[ƒO…é8»—Ä®ÈŸ‘Œ Þ[¹iÞÞ?Áx¢Ë]†ÚÓÝþðÃw	~YìÙ2ö†¤¼0ôÆœ±ØZù#=§.[Önoš”]’z¼ÿ§Üór’®Cqî¯ÉDé´tä£vòÐ#ºà*ô„Îéˆ£ÀŽgãÒ÷£	ÔíÓ¾‹Á¤6aÿ2TV`HËÁVàuI';ÐÜ­¢Q>yÖ±H¹÷CÙáˆ°"Ò§üzZf¦£±¿%îv G-Ì§ïREúYûÊ`‹‘f^ñ‹–+Q–ÿ–Ç4;³Q»íÕ~§â¸¥¤lr7T´êUMüè,þÉý$1“CzUÝv% »UØ1ŠPæÊøØ{ä„³0i¥1òqœõ¥ýµœ0Ð]wRmL´/«»•hgHÊÁäwŒ8¤ 7àOÑò]Ñ’D»›9‹Ù&ò²ÝŒ*Ú5Ý5—=³woGPZŒ‹ØZŒÞ¼,L+Q–ƒáôOb™Åù÷ X2j¸qÔ“©{úo+WŒrŠ]Æ_¹'x{ˆÀgÔ,"YÆèc|YÈù
+äJÔt4¦ª½('ãÜ‹û.’>›]¯+…'O°ò•cÖ’í{V2`ß®œBø0ÛÿÊþÚÔ‹çDF6ŠŽR2ÒRyÍgËtŽAë€JiÈÿ®«òtSª>×¢^øÑïúë¾È7Ž~C×oš''#¢£E"ä"zóÿ¿.Éçêj0§ô­R<¨ÚÜÕ&´xÑ…±eÒ oS~d9aw²É•;2Ÿ°¢]šS´ë¸›üÑ*Új¨2™lsë_,”ûÆÀÁÉìDfòTo~‚°.>v˜©”#Ê}¡apJ5eþŠ<¬(g©ê‡|~âááxÿçÔQkÓ‰u´qÿ2Ä©åé£åZ" ]Ézž¦ìÝì…ÕÝ'O"¯‘…¡»Vvj¥o1Q-R;§Ãx`¢KT;šÛÛÁ[1‰AŠÓgIñHÙƒ=½Ì‡‚ÕÛS4Ï)gé¿Úåt'”«1
+*ÖîÙ–©uqe"K„•c°ÝÜxÖŠtûØmÿ¯òñð86‹EåÓ7@1íKvÝô¨£S
+uDX&+¡Š_b¾¹_¯ïï?Æüêþ~]ÿ3/’D“¼ï~(%¬@ÀH!}Ê¸gÈ'TïÓ'}ï´5gÅØRª‰Ê=¥,b7âŽòq©{B´Ú ;Ž1þªŸùø¯
+endstream
+endobj
+312 0 obj
+<</Length 2098/Filter/FlateDecode>>
+stream
+xœí[Ýsä¶ß¿íCOS,~·ÎµwN:m§×iÆžéCœ{cç®ãËf;þ÷h%H‘Úõzw›ÎùE")‰À æ¯—«÷·W‹¼y{6û(øœ|dXÜÏ
+?Âh¢¢è¤e]pì­4ñÊFøiñÐ<xŽÜ5g™á®énönv;ûföõÛ³y÷ÎÓÓùëÕêjñîæûoç¾›ŸÿëzõŸ7ó?Ý\}³œ_HûïW?¼¸Z½|xõêÍWB¤e…AkÞD¸kTÓº[·¸iõ·HwönöÙÃìGP¨œ!ÅÖ­ùìû>tÀ7q4DÞKs-jÛpÎ‘ÐÆ Áb ¸
+ƒÀ¨ÜÑù‚E§(  ‘YZ ãÑ8iß‹Î4wAZh€#Å „ä`lP… Ö¢×òLD+]/C8F²M çQiXÿ1 «ˆDp'ü›ÈÁ˜ÀÀdP;í:Š*P–ymð,z€™1’ÐKƒ ZEÔA ÆÀ´\  ²Hr½"Ö÷]á7¢×ýÀ%ySÿ€Õ¨Ýº«¥kQÑzv…}o›	Ùôî€}D/¬YFŒ.`Ð;`µÐo’‘çc@ïÒh¤#Z
+zŽƒôR³ºN­W—a1{·¦^^ÆÉÃ=…žD®NfÜôHéÉÍ"Š`Ða½½µ°ÂJapˆ5F×t…/a8ˆ e@« RlÖÂy™-#dÑhØZÇÎ?\=œžÎßžýù+PâôÚí\dŒì¨£I{
+YéÈdõ,cl¨ÏÞ\€‚‹åüVi¸¸÷ß~~©”rr¸ìÏ,mu©¨ës{nú ‡_–®üºÆ´ƒTžv}swßgÃÎzº‡öõz}Ö.í<Ÿ|wñ—Ù×Òü¯W?|~ópR”¥Ó®w%qU”—Jul·²Q:ë·âQ6òÉõëdtÝ[eOú‚¸†w>Fn›ã².2.JJRÍ®¢âEÕˆàW©\:8u˜kÑ¹p×Ërxí³Ís.Ó•éqOÉørŠØKÅ~H	Ûä®Uv/'÷&ó·óôó·Wûg5e<¤×3IôçuuJ¹¾>—Ã/úVªÐ'Ùûôð}Z'ÔÝ–äÛÉS÷ï¬£QÑHu‡B£*^·½µÊ–}ÌLÂ¸/.{*º~)óñx\S7ûòéËÓSm3PµÜR|‰
+ÈÉ· R¶ƒýÝ½t³¹òlí9[Ð¢m¨Ñ”€h£CÇ|  ŽøÉÎ½”†°·ZùSÉz,ŸbÑºþÅÕi©ImZî©Ë!ž lèìrÃ–â»/mëëh‹ëè"*“lª´—Iâ¦f]e4Òp¶ZÆf¿8¹øg™7"$X,’²7HÅC¹ÓvÊµäýNFÓüVa30Ô%(´ÄÁ8© ¿“ÃéS‘Öo:“”9éI%¬:ççÖ:ò}p&"ûÃ˜°­|Q't2ÕÅU/a=eÂú7&(Òe°^Ì“6Hu©‡¢½a‹ÍQíM¬,ÿ˜”½­ÿ—©ôâ÷[)Im7p½…¿YMnÎFžµÛIô;Š\eˆã¯û³ÛÞN©$ÓD(]LGXE¨)ÉD(iÙ”_%âÊ­ÁË]^·±ãi°TBºòÓË¢Îm]fÝ2 )Ï=n®ÓŽ~ƒJO[Õ/+NUEúûî–	À3Æ{Ô†X]l–cÛÞ'aµÎ3²•+)[edTÔ¼Nãž“âv${ÓÈ£ì´y©Í’)ójSÊaB	LzÖ£u‡	3”×ê£ì×c‚îbœft“}?ªîVâ´1){“ß!Â›îeŽb‹H­6×¦LhŽör^µË
+š§ó’æO+¡ÁÔ^«òdrïíJ}¥*¢“zÕ1a*0Ó²7œþ![æ,í–»ñ§¤FŽc*RÛi¯QØm¥ŠQŽº+	ýì™<ÌHÓü•4ÞVfqÅyÝ§	8VeÀhÙàh
+HU[Q´h#p~ß²KvºZlŠ5·°{›2¾›T'ƒn·ƒÊ÷/íõey¯6Qƒ¤"Ì-£uæ ¥ï$âêªÚie¶Ë)ÔR|™È3ÞÝú÷Tgnü~Êå_Èá¥ræÉZ¹f:„O¬X>!®be’£| Âÿ“:y>˜á®Vcë£ ¼2“÷ùI»Ìn</—–mÕ³,ën»Ó.òíõ³”ãÛ¶V-dÞžhš€e±NÉÞ¡Ò‡Šövªân'‰ë…’çW|·S’Ê' yreèîÆ_
+˜bèQ
+¿ò{K!ÒŠpÒšþ6_ºlÇùŠ¦ðXŒãÙ:äCÁ±OçÔäŸ±—%xê©þüþŠ	ö]‘}è‚QÇÍBr¥ X¤f¿5çŸ—kz)U'FkÇLîè+¹V£
+Z¡>ö,˜<«=]ß;B$8±:ÅƒQ× éJ
+¡@ËKïÓ­ãéb2€\óGËqËÀŽiy©ã½ÔñöYÇÓ•2Â}ò°2ž.†£ò_‘ÐvÜŒµ¶–¨y)æ}rÅ<]ŒÕbó·Ÿü…wL¨VBµ1/å¼ÿ¯r^ñ/Ú7«ÕãýÇiÿøø¸ªÿH›~€‡F"ì®,rvÞü°jå÷Wi5Î€«Á6ÿÁz8?û(´ðo0ð¶ýÿ·ý‹uv>ûf`¤ç(@œò0å|þ8ßí4‹e”	3Ù®´/ó^š³—|¦¤îÀƒLÐ@ˆVt‡‘c#Æ×C;ò_Íkñ
+endstream
+endobj
+313 0 obj
+<</Length 2328/Filter/FlateDecode>>
+stream
+xœí[Ýã¶÷_1íÃ5ÛkÇœá7pšÝ» -rAŠ5Ð‡lvuîŠ]ïÅqä¿/(K²H‘’ì³7è‹%J"9œùq¾8ž¶Ù¾_Ý.·pùöjö=ð×p±žaù8_
+Xþ ½ò‚¼	wÚ8ÃV‡[£¬Ð~X®«Ž`ˆAÀCu#<Ô#=ÌÞÍV³ÏÞ¼½š7s¾z5ÿl»½]¾»ÿöëùâéÃ7óëï¶?¸ŸÿãþöÛûÍ|î¿ºýîýúvûþiýé§—¯‘š:)%Xåá´ÕÝÃîŽ«»ö“Ðœ½›ýg¶ž}…Q$X›Ý:Û¶í¬›Ø+"kÃíŽT-<°@éjåì	µwà4:‚G çÑIŒÒÀ³è­ƒ0>Óh¤ä$2‡»%²¨L¸ Rª¾P]¸C¤É; $K`…Â9Ð­}<êÐ´ 2¨¼ÃH@½r`,
+	Ë°~ï€…G"xëWžRŽI¡4Ò 4ä…#ÆÕÎ:Ðh…fFO^
+0p …GéÄèØ/ˆ4RxO„V‘EmÛfX¯G+Û@šÂLm-Qš]S†¦FA»ÑµË·ºµB«àØz´aiš1<wŒÆ9`åÐàÀê@¿RH*ô÷­u@B¢
+ eïQ“oÐ2°7èBK UÒ5b']†åìÝŽú0$àZ
+|5a4ÇU‹„
+­ðq`…S¨\XzýÚË°q@,Ñ›ªÖì£Ã)3H¾ê,ÃúÈ†ÑB–ÕÛí±ë·ëW¯æo¯þùD³qÚÝmŒ—hXu¡.mØÎa‹KÏ¤ WáÆ°HŸ].@Àb3_	 †Åª«/,?¹BüåbñßÙ›E†êâ4fI!§$I+A ‹Šš@‡g¬õ$Z¾®ˆ¡ðs#„Ü]ÙV×Í®E¦~k£·Í×Ûº¥â¯Û¯vÏWuË$×º—Ðuï†Ñ}??hï^Æ}9¥OG×»˜ž–>Ó¡kd¥L¹µÔoãõ×#	Ž9:m=Þ
+É	&z¿‰ælÆTß,þ•ÇgA®$s4²X‘u³Wž%ëˆ!ë,ÓâÅo;¿µp©TÃ.“ÃI5$"6ÉÍœ|_tÕ|šî2½Æ2èóÊ\qûóÓÛ¬0¤îãêº2ˆ:˜×pWI…ƒòqº²³®¯¾~okÿ¢¶’³ëäü‹ÛõwŸÜ¯/²Ó!;ëÍ±hà!=s#$u7ÍN$lp~Û´ðOäÝn“¦_Ón¶ÇRNß§ó±(o!•c›v-±8zÆ¼rˆÕ‘lhWÉWô’Ïª¯H9¶¼áÎÎÛäd³[l¤²T^”2»ñumót•_`2B£÷“yÒ?¢ÇS&×s¯ò60m·k´neê,D/Í™ 8nºV´{,‹³›/ã®»!]<šÎFD±&oà—u ^Wáçu,îÄyhá!õ$ZŽâÕ!{3z×=ïŠ%P^í9ñb‰&‹Ä@b©s qi½TËÅêcoºîÞ^~2‡Šiú+­ÌªÌ®æQª­ƒÞ7#À›¦u[ƒÚ’™÷Û/ÈêºiùXa3®ñ'@Ðf!È
+¥Sç‚`ãÆìi7þvåŒ*c5z^|$tÓR^I¦–¦ºéÐ±b•\nÔžøÝ€ð[­S vò¶5Æ‰njIåCÂµT+§‘H;j¬gKÏWãXtY,
+U¥FÎƒÄ„Ý-Ñuû"¿ëöf¿ÇÖy`×’h '
+Rw¬ñª¥’x¦©NDBCx;Æ`ò¡Gýó(íÃu­â‰7ã ó9€)§ÐI>ÀxdÑ	ð6¢Œ>R©§Ö<µ×çtí‡ýÌgi§Ô%mÀšaÂç™}s)ïá}L¢lš‡¬Ëð£l’Ti‹á°àY“¤…,i†–“í…¿Mó
+.ÝXtRHp:Ïad¿áxl »ÙÜ§’Ù=/teº=RNž@:O¬’8yKXêâX¥mÐÏÃ¼g’^ÍþÍ“9+Sƒ¶Èª·úa4h+¥ò’õì¾]@<››Táø1Nãº€ñ>-Ï¬žO•P<2¼ý„Uí|?î¥”íÊ ðMnÒyÔgÒ©¿¹,Þé“gÉfe¤Ñ¨5?¯&rhôi9}²¼äóuw&e9ævåø‚7˜ø“‰"Kú¨lò;ñ"z‡TøIT•$Ù§ZýTfÃg©µ}Þð…E•}Z~GE‡¹kÿ/ëˆ¹¤¦æ!Öõ…°Y2á¹Ìd’–‰ëq¶´f6ö
+ùLeP7‰aOLn1q4°†~¬G¬0¿ŒÑÊÕNó¿*§ê$’ëþžfcê²±Ýx¹ucÔšbgÔ„Ò“¤5¡œÐ'˜˜¤®ßß*ÓØÃ¼º4×¿?`I¶¤ T‚²‘Þ©4L¦qIÓ.Jª¶‚ëeÁû1#þMRî•–}µ`7ÇÖo±4ÏÎPÁÅÙSw2¿-)’EIEA+ÄœkÙÚÜRt¬óÇ^—™"¼^ù„(œZÙDêfZ±Žëu{ü©«ªv­ÈûóÎBì!;XYGV¡ ØL#•uÅ:Ë‰µtõû»Œ±Þf-C\¹ÙýrÝy;úÉaå¤¾EŠ{phàTHð%-ž#	—Ò“'9PÈÙc_R•´ÞŸ«Á’)=I²>»åûÒì”ÌW—äOÑJÇîÝìXr”œ›uû1ÁG’ñèä°bb;9y3üÌ¶Ä¡s!0YM©î4rXVl–2-'1í¨c¦žjèUQdkb~…a%çXBó,Î{üÚ‘«(/Ý;Š/ÃRf‹ItNŸM1žª"fJªjšöí•5$…	%™÷ê	â,]’n™~”ÚCÇ&AA
+a9ewtè³G—œ²íL\Î ¥Ë~VÄ28‹$¼wú=>H£¶ìßB/Ÿ¶Û§Çý?C?zÚ–ÿ§¡
+nò	ÿp’ìv‡ž\\ˆyPzÕOÈsdë]²q|²ª¶pÂ"Z')51q"7f)Í>b¬ö¢î0QK…æ<|¬ØÝ,õÿ œI3|
+endstream
+endobj
+314 0 obj
+<</Length 2309/Filter/FlateDecode>>
+stream
+xœí[Ýo#·×_1ÍCpFš‡ßLœrN‚¦èl ¹<ØŠ•»Â–/ŠŠ¢ÿ}ÀÕrµœ%W²­UÔ/Ú¥vIÎœOîüëõæÃòz±7o/f¿ ŸÇ‹÷ó…€Åo 0è (Øxg¬·Ò™xkµ&Ào‹UÓñ,Ip×\ãwíHw³÷³åì‡Ù·o/æiÎóóù×›ÍõâýíÏ?Î¯>þ4¿ü÷Íæ¿oç¹½þùv=¿Š÷ÿ¸þåÃêzóáaõúõ›o"‘F
+ôJ)p:À=-š»»ílîºWbsö~öÏÙjö+V“ÆnùìÚ.´Ç7É ‰œ‹·[PÃx6ç2šàÁô÷@> W$*w@Þapâø@Þ UW(e¼[ i‡ÚÆû; mÐêæ­ÐÇ;Ô@Z"„daR£ðŒA§bŸ€&6]$€,êàÁJ$ ƒA{°…‚Eä?x" ÜEþu^k/A’Fe•µ@h)Od×xçÁ ¤”(ÒK”¨|$€$zéAÅD)>'Bg€È¡q]3òÐ©î; Cq¦®ƒQ¨ì¶©bÓ  íè&Döi”F£ÓpÒt‘5#1þï%ZïAjÎ‚Œ¢Žôk¤cÿàÑ9$êRò,:	2Xô±%šÕµb»º³÷[êãdÒ"9¸/ÐQ”«£yÙ´HèØŠ/GQxÚGÖÛÇAEV¤è­’
+ƒmš‘¯È°‚Ž(á¼E
+Mgù#Gc„,š¶Ýc—¯Wççó·ß"mœnw;	6HÒfP÷Z‘r
+J¡‚$Q/ãÒ4PŸ½¹WëùR )¸Zö†€«û_½BÌãOˆ?ï„¤ö*·W%ó¶´Û«HW×^u¼~Úo4=>o‡i_'Å¯g?]ýuöíUA4ÿÛõê—W·«³¢@¬jÀù4y¬ÊãP¦å6q·½®Ú·Äßô™MÏ’<jòÛJ¥£ûŸ\þ¿ØR°ÎGmÅ˜ffÂìú¦¹ò±6½iæeÛŒ~Ó›iyl¶¶Jä8R¥1¡}¨ûÿ”»ãÚæ+¯Bem„«ƒOŽƒO+NO„>&É8þ$rDb˜uL@H OÓ$±l¥¿®GeBUðO•‰Ü³#¥´âYÖb[¦Ã’.+¸î=—?çý»ÿó¹w€NÏ5{îŠŠó&[	•õ]f­üÝöz¬Ko¦Õì½wÆTx>{Mr|f.Ç%™è4ŒÎ¦[Ž‹+#{¨ÑtœºN,Z)''Wf-«7liÆ¢ê³˜—¾Re©q\'¡—×˜‰5×·‰înYxº>l™*
+,,—I@Œì‚"Îªü	UÙÅ¹›’±Ëàžo¦eq)™ªC¥)¢ÒYôÚN…Jf>r¼eR^XN«ÃuTzJÅUèÉÎÀçÖe§73ì}Ç&ÉTzeÊe‘Üœœ¾úKSæ‚ØA‰„hó‘3Õ›6iÍ¨(SGˆ-"D”®åbûÖG|èxc¥?<þ|võ¯2n@‡7X¢ähP}	øÅÂe¨üß›–ƒì÷¸Â}Š÷Ê€:è©ÜLÊBìhÏêL…â&¦Éfœr—“¨ˆwHËÑÄû³Ìß@©´uÑT—<ÝòeþDmM¦3#3ïÑæî3¶íú·¢¹ƒË¨¨YÑnËª¾ÇžÞf‘Ž·Äi{'y·rI:ÃtÕž§Ž-yC>Fò:T†žöžÊGï(ÍÒÁîÖc„nYÚ¼Ú:kO»yUE‚CZŽ&Ad¶£ä{µâ´‡;FÝîËÑ•»mÛç{b¦;:ü—gnß~/yÆ÷×Nk¥göîr§ÅX+‡.œ¦¦Ó)ÇÜçfTÛ×cØ:6G-C!c”c™S’ÛŒ²×ËcßÔ7í9½êº¬mhRècÅå” ©ÄZŽ†KCT·wQ	UòVÏs'8y¢ö¦¤sË©Àz<:¡ãí$¨X4Ó“”ŸÞí¤¬³W™(W¥Òe†Kûœ§kæá|Ò«Ctbåœg'^62÷*ºâŽx\ñ,q¾-Ž<¦tFË*–oíTå‹Ößì)JÉƒVðÉ…4þœÏ'ÅHñ§X‚U±èë'*p¼*júBò¬ç5‰–×WÏ¬xäqY®~JU†ÜkDÉÌŽ§ï&÷Öö$.jfàyÊzí÷ RˆB£$y¢´qÛ>+‡µƒ€•—?Ïrî-ø¢çU÷²›Vqó»ø„o	fóÛÑW$ÇËdƒÜÿãÒé,ÌN~Å«À¾Vb åI÷n+–}‡A8?ŠÍb8,ãÁ5QI£,ó}ßX°ÉÎu¸ºú(±<ÞýÏ”j®
+ž«PÒá¦ý§°,ýÌbŸ¡§Tt¹S;jñÀ‚´­	aš¢Æ@UÔ¡›šË¸”Ý­_çrÙjçŽÉWªí²Œl­[)®åv;?Ï‘Çèß¤’­ìg‹7‡ ï°’âÂŠ9—x€Ñ{5ÂX5¯‰çÊæ°àvŸïÇO
+ðTÙ7¬Í3ä£ö>Oð)%WY¬ÊÇÓšJÄƒš§ÌƒH[Îƒ©9†šSŸÓZˆò“nµ‹õ„líÏÁññÇé¡í{Sä¬¿Œ?çEm‘ê,\sò¹ŽLa9/ÈôUÁÍ|F‰UVroÏ¯ÿÎKÆ‡µôÛ ÖíÛ…ÕcN%ý1’r²˜”#§Ð¿8¥¦
+Ô”¨y)¿Y<V•sñçÅDà;FùXs9$z¡…<éV²"Å5/%äÿ»²*Ì$â7U§u‹•® uHËKy’"òæ¸‹Ëœ A2¨œàØ—¿£iÂ“ôWÎ-x‹ÂL–vf&-g§øÍî›‡Íæá~÷Ùîw›úg»ù	EÔ±(™J†—Íç±&~lï)È¨¼i¾ºupyñwhà? ámûµqûÍììröW-ùg8²aÿ‘2ÀmmõQ`™¼–ãe€÷„G»¥î	Ñ(v96bü¬¯¢V'&
+endstream
+endobj
+315 0 obj
+<</Length 2511/Filter/FlateDecode>>
+stream
+xœÕ[ëo#·ÿ®¿‚uƒCœkGœá»u¤I‘ZØ@?Äù`+§Ü¶|Qùï®vWËYîÃÖ®Ð~‘–û ‡óøqf8\~¾Ý}Xß­vâòíÕâgB
+)þÿ\ ±z\®¤Xý"$$¯Œõ–œ‰—V;i‚øeµ)>|IHñPüÇÊžïëÅ?_¾½ZVc^\,?ßíîVïßýøýòæéãËë_ïw¿}|·üúÝÝï¶Ë›xý»Ÿ>lîvž6oÞ\~‰4$Á+¥„ÓA<
+£eqõ°¿¢âª~%6ïÿZl?	Òj”dì~žuÛ¥6æ4¢sñrÏ,&Y M1s
+&xáx} ¯¼ PV<ô‚ó"ö/Ð°Ê)Ð+ ŠW+Ú¶ñúA 6`uñ†Vàãhš ƒhÅJé½0œŠß0±é"hA/,
+4´ÖTbç¼  Q<Äùë@^kO‚Pƒ²ÊZ`1HAPì×xç…'½ "éÅ¨^(@ùH xòBÅ(`|ŽÎDÆÕÍ8ß NÕ7Œ#ÕÊî›*6HÜ÷nBœ¾3E‡d48-¹ .NÍÄûžÀz/H{pVPdu¤_k@¿œó¥•”B ƒ^Ž>¶$`!]+÷Ò%±Z¼ßS#èÄ£ðF¾ÚØ›§¢…RÇV|9²ÂkÐ>N½|Tœ
+I	Þz¤ Ø¢ç'ì#£ã%½@oCñ±ŠóC{c„¬
+ÛÛØõÇ»ÍÅÅòíÕ7_YNmÝŽ„
+,é¦ª+Í9š¸
+„Æú¨ô:^XòQÓ—7BŠ›ír-’¸Y7ñBŠ›ÇOo¥”8¿ù÷âË›!Ø"ÄÈ’‚^+TN		$j"-ï‘1£hù¾ ãÏ­”jÿO®øßî[hË§.yZ½½+[:}»~«¼/Mù¼C6Ÿ/ãÏïê«×é·Ä)0Éÿ}:bMÁþ=f.„ç?Üü=/Ê*†V`í‹¥‚d§4n¡T0CTõ¼ ÿ“ø#Ê	V*¾üSãIÅÄý“[)mó‹â¥³æ(._×M)+JîøXJ“0¤æwñþ«f£x£œ—ªhQ¹ÿ‹nÙ¨¬lP‚“óÈæusþ%g¥K	l¬ÜÅÚüíÝoO¿î²”JjPzu]¬~&®¥ñª ™"ÒxS,ªN\_}'$ñ¡ÅÛÒ™(—ÄÅu†?:7ªqùYdÈÐ!Õ¥6Ê,x¼ù®SÞÄ1mOÖ9»[!38äÆÂÑ­z?KþnùßMòÙ¦¥:…‹†õr+žT*&u°É*¨ñ`Í£ Û„gÉDj~5Ÿ±Õ°|§j±U®œrµ"“GÊç|_¯)³ïè¼ÉQµ<´Íî3–3ÈõÙ¥É/Y³·­UâUBW%Ì7Õâ´çjÝ2Ãªh³ª¨¢lOâuÍ‰PlÊióz@vŽá£ù‡ï¹3ï 0Üsæþ·S€Ù´xøTéÖM—ÕM3­á½ÊÒ;÷Ø0;€ÓÔS]çGk‰ Ks+x–ÜJâ€¨©a%i§‹
+S‚<lVª¡øø˜ò´âUª–¾y/]­•Äl¢˜ŠÑ6D}NQu@3…®-_#hÜ™^V°Ö\„Ú¼«ÁoW­%1•Õyú¿ÁºcÁbŒó–ßÞm~úôÝæ¼¥u:˜cÕâFøaâÝ£ì¦8Ú‰ cþk‚kù%F¾çÿY¢;†XÉ²^½=‰šÚñ-†ü3….O‘ÝJ‚TÐÝãWïnß·Ö=bj§àðÇ
+¨/áµ;%Hýzc¼£¹½á±ŸµÒDLY&Éµ¿OìÓ²JëøÚYuž„ gÍ¼ZÒÊqÎ{t"›jÒ¤‚=m~Xw+C‘)Î5:l[Xð¦!’9t¢|Þ'›v!îÞèc91”é*&òYJu_~à¬ÎrwæËT>¨nâ˜õfÚIÝedšR—¸rSF¸•h;T]j˜+QôBVqO®öØs¾sÄê@[¿Ä¬U°KˆùˆõÚŠ¯0+ê|l ‰5 œ©gÅèRi_)wy5äÎg‹žçøn.¯‚ÊÇÝÕy‚µ,r.|sÛsSÊzjx¥iÏ>ë•-³•ÍQºCxø‘ð²o{³!¯²œõ§uzâ¡½ª¶‰šÌ1à‘(±Åûj	Â¥áÇá#¶Úàa»³Ï öV>z}üüG¹>k™§Øpù:k»c³m½6—&øº8c;nM¨5©üî<›c¹¶>§Žú
+¥%„´šk2åø=ƒÛžˆõ9»7]»6u¢.«fŸôð&[ë ÐŒU'Ä2RCXÖ&j2,Kl˜V°ˆ±‘mªk"Û`µ°:õ›¢]°µ·óIêcY1
+Öª}û|J¿2Ê>(ÉVµv‚0»á@;9Ï¦¬[‘J~¼y jŒR coñÈjÄn™¼MPp0Sš}p{z†Â…Ž½ß¾d·pÉ) «Âi1r –%kÊ´K·Ôq¨lz\<qËÝ³ÄNDy}@Õö‰ÑyðÇOzXýuº}ÃŽrÆ-óMòQE½®–éÝw:ª¸Á9)—¶};™½:´Þ(Ð>–ãÎégMµ^œ'ßT¡&÷®RÅI6­_8\*[uLë¬IÒIKábåÈš±–MfwžÚ1Míçëê»û\mlõôõ˜©¶SL’¦àÇ(0kltq´áÈ1Ï/»7Ê¿J¿cØ— ãYÓ"aAo>cƒ¤^#}§!ðYÑªâìÑ	Õa"2Ù°ó©D13¦%SR†n{§Zb¾Î'ek®Dò¸Uè…±§Íúõ>[QÏ+9+%ž°Í `gÉšÒÅœn‡þY¥}`Ý0x°Çób‚0¹»(–ŸÉ°#|Ô*“¢ÙÖ¶ßBi:wG&ùŸS ÇOùôˆ1[ðˆÆG‘Í„®'-Ç-‘gÝ[7nSµë`Öˆ
+êî3¦ £`×]üÈ29ëaÏŒÃðy¥Êlï‰¶“ïQÓìÞ*ZúÙœ€®²ëÎ˜®9»û¬w©[Í£;@ù!¼iç@kSJ±„›R2Y“hj•ÓæÕ%TVÚ#þ?z°Š‡ƒ¤Ç¯4Üú²ÁÏ7ÿ+[ÝìÓíà—TqŒ;ËÁ¹
+í²í/Ÿv»§ÇÃYû¯žžvÝgí“ª|	:oœðTw6! 'Õ_èk†§÷†•Á³ŽQeŽÓ3p?Ú×`¢QºðgàcÁFÕÔ¯ÿ»Vö
+endstream
+endobj
+316 0 obj
+<</Length 1051/Filter/FlateDecode>>
+stream
+xœµV[oW~Ÿ_áÒª"BxlŸ›¡’@Õ¢¦*ÊJ} 6C–¤ÚKX¶ªø÷ÈsËÌ0IQ«¼Œísñ±?_Æåóýázµ¬prvZ|‚§FR¨6eEP}Âì3qŽÆ…¨QR06úD!Ã§j[_Ü@d‚uMMÃºÕ´.®ŠUñºxyvZvo—Ï‡euuùþM¹ØÝ¼+Ïÿ¾8|¾¹,¹\¾¿Ü—ãÿX~¸Þ.×»í³g'/ÌÈ „êœƒä3l xª¹uÃIÍõGL,®Š?‹mñ)z&	±ñ³—ÓXéÀo–ì™S2¶€kÇjÏ%3†¬ •a¬Õ)ºk`M˜“‚éÖ€Ñ)°:1®ö	}4~ìF_ŸðÕ8ôÀ^³#G¨@<’*„€ÉÙŒÁÄdpDŸ¢ Ì^!&$•ùŸ„22ÃÚü÷YÔ{öè¢‹#gRÎ ¦7hR˜HAD0³ÙË–
+Ž2:5XPEÁÙs@¶}fL˜†Ô‹æoÆäú…5p`{©¿ºØˆÎÄ€ÄöÍýj…<&k”1™kAÐÖU0ª‚xÅAj³ß{do÷³bJ
+L½%©äŒrÄ$ 9¢šDÈut#5Ñ¨Š«Æz{L"r‚(abÃ5š6•Zbò&ÙaƒB=z5×ÛíìÌ!B
+,s¬EóËVÚ)°Fä\_væ'Ó61¤ª+¬©±ó›åöø¸<;ýõPùÛrûáñåö¨« ¾Ì“@Ì£øQÎ«wì’B!—…ƒ¥¿Øš„:ç‹“,öåŠ€«aç XlÞ<~KDjŸ·õ—85Ô£A|C©¥®¥"--åñ9êäö¹Ñþ¶}Ò¤ÕšƒïÄà±-OÆj¤~ÚÅ4¶º×Ð½ÙÈGGï¯Š—‹™XñW!rÎ£þß(ñ}Q`&~4òQëM‹4‹y»E„†û8†¢ôj¬²y"¶öã·{ËÒ(¦Ý®¿Y™MþÔ´Ø‡€µË/7‡e¿Ú¥Ñ$Ÿ{¬»üî`ïï'U0õÛâRÚç»ž{òMÑÑ‹¹ð5Vý8TôÓ(Ø~hû4›¦¡C¦Gbœ·È¥ÿˆè÷›ýWöyÚž¤ªÛÏýIçf“.x¤$SËû‘7ûù*1ú}ïÞ£qo„çjÜÙ¦=ÁNÿÐ.†1B³àÉîpØmngÀŸw»ÃÝ3àÏ@è‰¨ïŽ§çõ¬lr3®†VltÕPp	ÎOÂ ÿ€‡³vtm°â¼x=y€3«MP·sÉf_SZ‡+ªÌE§Ë÷õÞ®ÂÆîbð?ÿÍfû"ßÑ“¥«õn}R5m5ÌéœÍšî‡÷U½t`êˆÁyŒƒc£?ZüÕç×µ†ê 
+endstream
+endobj
+317 0 obj
+<</Length 2455/Filter/FlateDecode>>
+stream
+xœÅ[[s·~ç¯@íT±’ÄÁS×m¤$“´V§k¦Q$FŒ‘(Ga¦“ßÁ.g–+É›¾{ÏåÃw. —_Üoß¯/W[vrvºø™L°—ñËÉV·Ë•`«_˜àAÁÆ#c½•ÎÄC«0ý²Út/Þ2’	vÓ}Çnv#Ý,Þ-Ö‹/¾:;]¦ß|õjùÅv{¹zwýÃwËó»ß/ßþzµýíÃõò›ëË®ï—çñø_—?¾ß\nßßm^¿>ù2
+i¤à^)Åœì–-º£›þHvGù‘xºx·øÏb³ø™	.¬!íõÌç®´ÐdÐ ÎÅÃÞÐ)M M§¹ÀMðÌîÝ2ð{å™äÊ²Þñà<‹ã3ð†[å™`à—2­hÇµÇ7´áVwOhÅ}<âš–‚gÀÁ²“šï™1Ü©øNà&žº( X®ƒgVr``xÐžYÇ…b«¨ðLŠÀØMÔ_éµö’IÐ\Ye-n!É8®ñÎ3ÃðLJÉDy!ÂÀ3%W>
+ ’{é™Š7€ñ> w†8n\>úîT¾pÃÀ@ü¥ü‚Q\ÙþTÅSÃô£›Õw¦PÍf7LºÀ]TÍH¯{É­÷LjÏe2š:Ê¯5ßž;çÅu©ð,Xî$“ÁrÏ‡Î»VôÞ•lµx×KLZŽÝ2/¸ƒhWGó²;¡ãY|8šÂk®}T}w;¨¨Š‚{ëHÅƒíN£^Qa/(áxË!t/«¨¸8dÕÍ°~Ž½ýp¹yõjyvúí—L¤‰“g·“ÌzÏ…®îµå\
+$˜z¯IÓ!}qrÎ;¿_®“‚¯K¾ìüö»B?.„„øýy"ôîb<ìîúî\}?]Oƒ¥÷E7è…r÷­Ð}C¾Õ}n¿?ÿûâ«ó!uLóæò·»_·´±ÄÞX§o»©l"1Ä£Îj22£7C8ööôŸLpÃþË4;Û1ãn~/ÞòGáÖ>ÚEÀ@6]´7(døä¨dØä]RHS?ÜÙû|]IÚ]»Ñ°ûîG{\J€ ´¥ÇGò¬é_Wæa “œÉ»ïd#WIÚévDˆs_ª.kA‹WÊ4U£¼Ä™$q¦÷ÞÏ…3U[CaÄ8$~Ãƒ
+ãù0GQžÎ“ú•u%cÂXzGvYéû³ŽÖ½Úá,rSPî–’\•w2UÚ!B“Ê5”Î|<"‰H°@Î„ÈlÍšÙ„¢¹ ÝïlgUªsû†Ë˜Úýê=9‡j4a/&—$a,a”TÑ:K°žüKÛÁókzÆ&I2N{fÉIms¤ž}Ã„xa/MŒš£	–+egãN¼Êp;•Ê©ºWwœ¨JGáX£uýpÂËÐIlÐ¢/ìXÚ¡Õ/bXæ1R~ˆ¦S¶ÏhZ³ŒÈG87•M/ìá…äAïTîi¼9CBÎYnæBæðm™)Óô4 L
+5ÿ­§Ä?ïrQ`3c¶LÎM@Äa	¦{÷pï¾ÆÂÜˆ¸?ßƒ®©¬„êç>«‘Ú_ü=•šWQÃûÒ%m´!iIHËŸ»©@ÓÌŸ‘Ùu›Œ ™…7ÜMÎÿ°3§à@<ö®¤X—)žºî'GêZ˜C%™+Š-”ˆÐÑçÓ‚8ªüˆ®°{k™sN<‚PG"T9.Ä<e¯,ŽƒÔ¢€ÃõLw·ÀÀ~0‚”pN>‹ýÃ­/V¹Dmò+*•Â‰DWüÒôlá/‡@²·d¨àt¨Œªh¸ =YÞ?­nÖ3…”w
+gz‘à¸T3•1dñös™ûIß1‚giÆ+:!§¡Véwi,¡BÜij3AE?ü  þ5Z³Â¬Žë¹rO\Ê¡¦L6&Á
+{G“ RW¢j˜÷cÔ“§ÍIõJÊ_º“Ø¦Ñ±"ãùß†óôM9}ÊøA¤¦Ob,JŸ’}1ýà2pt*•Áb{@®Ihç¸õÿ§¶Ož„u¨ò¦™oOÒ­kD4²@í¨Êq*i8+e±ÊŒ¸ˆ\”ÐFpxüºÑ¸ROD(‘MëÐ¨ò§	GÄBÓ —Ÿ©p ›Ør£:11Ô Ü2æo=Üq˜œ‡Ž ”\ÒÐJp%gb\Ò	?Ñ=jt;YÀ`•©a>Ôt"òÝ“ÛyV±ZK<­ÎÞhWpÐR¡‘½nî2XNË`koÖfÃ¹p¡ã3×ÂEsQÔÓ²>Y}¿±˜Ð‚â¦Ë$¤Ixå¿Ž–k¢;ñ äûAK|n¬’¯².îa>Åþ±ØL®T(·ÇÈYötzÐçz¤¿¼'xìžed¡í›2ÈÞ¼’žË¸kž)ŽBà¡	˜bFQÝ6iÐå“¢íAëä”îÐ$iåUõ²5NUvVD	z²|ýNÆÍ(-Ô«bžÒe²5¯„çz®Î|xu#·HNF¤wË7—›_\oŽ)5¤[áž°#mD?#ŠÍäS¢çYþÀxJmrd7Ìç#šÛ`,·OÕñP…[Mã×43 æFrkùb”1Î&@wØm’N9¸áv:xñÆ. ºÛþ-¿ÐŽÂjVùÎ‘ZÍ½¼’=(Gös‰Ñ)*p.„ÇNNÙ¼ð­á%}’ÑÕÞ^ÏKS~?Xƒ×ÓâHºÞ0ÎîzïŒÂhcÌÌ•þX´.e­žJ+‡¶”½XÛnYŠ4èÚtç¸ÝÛ¡’JIûW©@Ó?òŒ$rÀ&ì?E‡"ÄÞr >Á¶ä¨KÑât?§h\ÆÉQN¬jØl‰&J™5à,‹Î†
+ÿ‰´@wörÔóõ6ûÇ¹áÌrŠ˜ž¥ÖŸÉcâ¶VzûtìQíãù´ŽI#h“£hÀ³3±^&v5°Ôf°»rS)%³˜ù‰ˆ‚’Ñª¶z~Ðc£9æK½qX¶Îgeöj1ÅªÏëm3˜Lòÿ¤½ÐÖÝUä#IòM#Ô¸)äÉƒá¢AàÈ´ž€<5Š<7ÅQ¾ H¨ÊPe•°DDNþ#ëän»½»Ýÿ)ëë»»mûOYÕÂ·à:
+ùÿ1¢‰ç|üKÓÞÖÊÅ?£ÅA;C[M­ã•§aúf$*á«3IiŸ]|ÂþÛƒùÞÕ…ÒÜÎcÇÎŒ/ÏÊøú™w/«
+endstream
+endobj
+318 0 obj
+<</Length 314/N 3/Range[0 1 0 1 0 1]/Filter/FlateDecode>>
 stream
 xœ}¿KqÆ?×U–X94%MQKS†Nø#Ô¦óüQ vÝ÷BšË¡©hˆFk	¢ÙÆú‚ !
 ¢­Õ †’‹¯ZPÏò~xx^Þ—”ç¼QÝŠ¶ùµx"©¹^PñÒÏ cº!ÌåH0
  ô’0l+Ï½ß£Èy7½®Ó;¯×«É¥º;QŽ?V.ø_îtFÀà3LËEÆK¶)y	ðëz”80eÅIPö¤Ÿkñ‰äT‹/%[Ñp ” å:8ÕÁ…ü¶¼+%¿÷dŠ±ÐŒ"ÂÿG¦·™	`d_¿{Ù¹ÙÖ–gzžçm\‡Ð8rœÏSÇiœúµ­öþfæë ´½Ô1\íÃÈCÛóU`¨ÕS·ô¦¥]Ù¨ŸÃ@†oÁ½öãâ_±
 endstream
 endobj
-
-230 0 obj
-[248 0 R /XYZ 72 712 0]
+319 0 obj
+<</Creator(Typst 0.15.0)/ModDate(D:20260908191932Z)/CreationDate(D:20260908191932Z)>>
 endobj
-
-231 0 obj
-[248 0 R /XYZ 72 570.336 0]
-endobj
-
-232 0 obj
-[250 0 R /XYZ 72 602.112 0]
-endobj
-
-233 0 obj
-[250 0 R /XYZ 72 217.99799 0]
-endobj
-
-234 0 obj
-[252 0 R /XYZ 72 712 0]
-endobj
-
-235 0 obj
-[252 0 R /XYZ 72 371.638 0]
-endobj
-
-236 0 obj
-[250 0 R /XYZ 72 712 0]
-endobj
-
-237 0 obj
-[254 0 R /XYZ 72 667.624 0]
-endobj
-
-238 0 obj
-[254 0 R /XYZ 72 313.368 0]
-endobj
-
-239 0 obj
-[254 0 R /XYZ 72 144.91199 0]
-endobj
-
-240 0 obj
-[256 0 R /XYZ 72 477.04 0]
-endobj
-
-241 0 obj
-[254 0 R /XYZ 72 359.328 0]
-endobj
-
-242 0 obj
-[259 0 R /XYZ 72 712 0]
-endobj
-
-243 0 obj
-[259 0 R /XYZ 72 384.552 0]
-endobj
-
-244 0 obj
-[246 0 R /XYZ 72 568.1335 0]
-endobj
-
-245 0 obj
-<<
-  /Type /Annot
-  /Subtype /Link
-  /Rect [311.4 449.1695 466.2 468.9455]
-  /Border [0 0 0]
-  /A <<
-    /Type /Action
-    /S /URI
-    /URI (https://2026.cloudnativegeo.org)
-  >>
-  /F 4
-  /StructParent 0
-  /Contents (https://2026.cloudnativegeo.org)
->>
-endobj
-
-246 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 228 0 R
-    >>
-    /Font <<
-      /f0 210 0 R
-      /f1 216 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 1
-  /Tabs /S
-  /Parent 1 0 R
-  /Contents 247 0 R
-  /Annots [245 0 R]
->>
-endobj
-
-247 0 obj
-<<
-  /Length 1564
-  /Filter /FlateDecode
->>
+320 0 obj
+<</Length 996/Type/Metadata/Subtype/XML>>
 stream
-xœµXÁn7½ë+Ø$-ÒCi‘”(	$NŠ¶hŠ6ÐCÒƒ=±ã »ëÄÝ¢èßÔHë™ñn Íe5o¤¡ÈÇGjfžÝl?\ž[xþêØ}r<|gC*ÃÚ†?œÇŠ§¢à±DÍÊ)Ú¥†äc?†³'×N‰ÁÃªŽfbåFS+wå.Ýk÷òÕ±;Úíúä‰8z¶ÝžWïàÍÑéõÇßíÖÉŸçÛ¿?^ÀÑgï.nìÖiÅ¿ž½ÿ°9Û~¸Þ¸§Oáù‹ãÑâÉÇ³M³öêøÇàûì'—´X;ŽãÕj¼¢€$aUWÜ¢+÷›Û¸OÎ#G¥œ4Ž¤Lp39¥‡¸¢”À#LQåÇ˜
-±(¢g`Ÿ±ÀÚIiP²b! ’1äRB/0¸ŽY0fh1ÆÍjCƒ\ónVÚRÅb`4#„j+•Ñw¸rA=fò)BˆI¡xL¡ï1‚ÁI¡AQBòŠI;Øù]!SDú‹Ç$ÝbCƒ³íävV	3ab*ÈT}P2Ò¯\ha±˜ñ¨¥ÑZ·éîÊÅ˜€¡WX» R0XU(Hƒ@aL&Œ
-RYBæŒElµÌrSô¨#¦š(f{lÄ*½m[Ÿ7‘ÆLÆÅÛö–®1’Ž®œ†‚ª@) Vˆ)Ùs¯:6–Œ4Md$²O˜@UÑÌ˜4FÔÜÑàTªLú,,FY6Î;²|E[Û0‹*„¡*1eÐ(–®†§ÉcáÝlRŒ¶V10_S o2\òŒJ¯\ò¥Xäš‹ÉÜ¤A#cî`pJ„%6m}ÓiÚ!“¼)ºa¦P£²Ú‰£hT+¨†Ìq±÷Ùªp9[Mš£lÂµ†ÐgŠŒl¨IJw±%iL#«Æ­×Žr1Ù¶X9Ê	K_e•#j ”Åly…„!ÕöK!bm\³µê ØŠÓÊzpÐˆÑ$µrT0ˆ©6 ÅÊV&ÑøÓ4³¯)H–ïL«>‡GÖDÅÄ‡Êä3e`³sÊM5ÌlÄŽÈš"ˆ/(Ù6&¶hÄnEóNˆ,eD©¶»Yx¥6œ¯EÂx»:
-JªHÕþbv£U>§h¶83±rœ
-¬âãÌµe„l’b#”€C@²|sÉ¶ˆ¼`°sŒKÁÈP´*¦(æÚ	jê¨æÎrUÎÀ¬H	Ö.ûú„W³“y”c0`I!kþƒ£q²ˆùÎÞ›¨kIiE1×ð²ñiX(«5{PŒüd†fÛõô}½ÿ´¤ÛÓr÷¢dŒ¹ÄùA—ƒ$ì¥0E;óØîqºç§ÎÃé;ºôÀN/§ïN×îÍã·Þû·ÞS¹ÒÆÐÆØFmcªãyýÝÎÖnFD2A—³7mE·ÕFmzö{÷ÚÝçæ+óÂNøöw8ýÉ½<=D/ï§7”ˆâ¤—eJ­‡ÔCàF77ºY'4{ö÷(võóÙæ=<¾Ø|{ Ú0ëBLšBôµ¥i²Àƒ]M^™¦¡ÿK¨-ÓÜ•žË˜ÐÞ w„Ï‰Øö¹Úò"{µ¶ ^Âb¿®ûîwóOvÚj¸k±Þ‡¹ ïºp_¾ÂžYãû³ôï¶Ÿ¨ƒT~5ÍÐƒmçsrFR;	:eòá49ÕÉ6ó"´$ìÐg‘é˜ê„¡ã“û«öäø'ð—ðª}&I	8~(JRÜ_G’
-Jù/]Ã^¤þ—¦,.ãž&Ý­lÏð=tJúÎç“¹óYÆÉ7{-nçoÑô·‹ŠZDÖýhåÚWË¢{ÊÞ&³]Ü·¨í}µªd–D_P½g¶^µ™SÓšMOÀ,ÔÖå6³Ä/šÕÎNïx2Mï—½ºçöÓÔ£ÞSý¤-l§¥ž&žÎ=¼õ&Ì=Î?XªêÁtöáç¨þ¾ì¦ÙûJ_,»÷$jNÔ¢÷Ž=ÜSÊ7“{›aœ§}]të¤_ïŽ³©sçöûõÒìèOw¸mOHk-wíìËïîHîfúÑ¼{Ý;Ø‹¾©º;x„Üùëùõv{½žÿÍõýõõöÞ¿¹þ'K
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><xmp:CreatorTool>Typst 0.15.0</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-09-08T19:19:32+00:00</xmp:ModifyDate><xmp:CreateDate>2026-09-08T19:19:32+00:00</xmp:CreateDate><xmpTPg:NPages>9</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>wtHU+wfi73t5ktiG0YqNmQ==</xmpMM:InstanceID><xmpMM:DocumentID>wtHU+wfi73t5ktiG0YqNmQ==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
-
-248 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 228 0 R
-    >>
-    /Font <<
-      /f0 210 0 R
-      /f1 216 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 2
-  /Parent 1 0 R
-  /Contents 249 0 R
->>
+321 0 obj
+<</Type/Catalog/Pages 1 0 R/Metadata 320 0 R/Lang(en)/StructTreeRoot 19 0 R/MarkInfo<</Marked true/Suspects false>>/ViewerPreferences<</Direction/L2R>>/Outlines 18 0 R>>
 endobj
-
-249 0 obj
-<<
-  /Length 2089
-  /Filter /FlateDecode
->>
-stream
-xœÍZÝo7ß¿bê4vÜ&#¿	·‡»CSÜÁî¡éƒ£ZM
-YN]÷ß¸»\q(®VŽ¬k_Ä%—;Îü8_Ôì›‡Í‡åÍb¯ß\5¿5¼ŠwÍl!`ñ{#0è (XŒõV:­vÂø}±nâ—w%	VmI¬šŽÔªyß,›6ß½¹jfÃª_}Õ Ì¾Ùlnïo†góû?Å¡ë¿Ûü÷ã-Ìþz{óóíCš·ýÜüòa}³ùp¿n¾þ^¹6Ò¢ñJÓ
-î£Eû´êždˆOÃ”¶û¾ùW³n~k
-­½#7wž0²¹(HMä¤N*ÔÊ"JE›V2šàÁôwù€^y¨,¬òƒó Ð+ oÐ*È+”2>-ÒµÏ«†´A«ÛZ¡O¨´D
-ÉÂ¢‘…÷`º¸w
-hb×EÈ¢¬D2´ëP(XDR$‚UóJ Òkí%HÒ¨¬²-á)€Œtw:áAJ‰"¿‘áA‰€ÊGH¢—T|A@dâ{"tˆ7tã~:5¬2W>0
-•íº*v
-ê¨›·ïLKPNÃª‘. ‹[3ã¸—h½©=:2Š:ò¯5’ŽßÎy ¡PG¼ÊÐ‡`ÑIÁ¢=Q»VtÚ•°hÞwÜÇÅ¤Erp×xŽ¢\m¤æeÛ#¡c/NŽ¢ðµ[ï_·"…@o=TlÛûŠöQÐq@	ä-R€ø±Šû#©Œ,ÚC×»ë7ëþÈ½¹úÛ· ¶Gh8øN‚õ…æˆ÷Z‘r
-J¡‚$Á/ã˜4â_Ïó‡f¶ Ì—¹10¿k~|ñVñ<þ¼Jv­°mû®ëÉ®'„î[ŠíYmª2±=ï_µÔ€‘íà³¾“(¦Vãé£ø,Þ
-²£!ç)}n8á2^7ùÜ‹|g‰óŸ—?ÁüïÍwóSYèVO"ÓÓÕu#Ð»¨(íŠÆ{Ù>Æe4\_ýÐ4ðŸFÃ›Þ^'s=‰1hí(! 9Ž’Ï˜—¹;Íœq5Rßªöåçý`÷µP’Ö[•<ß%Û+~Ééz•c¤ÒØ#FËÙì€”fg!ÍÖ%	gKÆÕf;V›¼æ[èA\®ió/Ùöj‹ðZ|ÁÖOë–È.&G€¦zïO´aÏÃQî 4Z.§~ßÏ™þí~Ý3¶(Ýƒ¦B°5tSo¥Nl.âßí,Ycü¡JqÃ·ÃØO½¹%)÷[Ï×ß·ýe!}ŽESãò‚‘Ó[°a§B†J5‚J²H$O‡ÊÞBôr»(íÕ³'4V¨“›‡´‡r©åð+U¼÷pÐ6[J°ë+¶ž 7ò‘}ò™c'è0ÓKãá0àé:ðL°¨”=ð
-›Ø‹›ï’Û÷vs—Åf€z'^: LÀ_ôÚ¡/ãÏË"¯†º<¨Ú5›u»Ý?Ó LéÁŒèA[TÎþ‰¢äŠxtpZøŒÞ«?"&5Êçb9UPjG”3¹SYä½¶äq_ÍòðÃ²ÜgS;„;6ý!‘»·Ï
-(äHÀÉ<KáWw]laé&·'èyL´×Ü>ƒœ2®ŽC4JyB,–QxŠR;ó>r¶•SÂKÍLg¶>³7…íMñ˜R)¼HI4§ï*AG‚	E¹%/r(™²œ”ó±Ó©¨}nùV£ŒE`èW³ª	±ŸÖ$ÚüÚœFI'C›š:÷uS¦Êƒ¸Ïš”!ÜN²ahk ­¥¦<g{lTÄ5,…Þk¸«G+*V¬8Û1 E˜~^^a†8Ö.µaú™«¬"OÎÜzçEª«UÏ%îŽBú¯’—áÆó€d³t«»z…«³íNÓ!b¶‹¢æe«%œ<*ÃºCê#ä“¥çúJ)7k¥Ñ‡“e4e“ö—°Uä<·=P:ç¼fkö éÎy’Îìrü-Ñ
-@&s!¢øøýÍúxq»¾Ñ§p¨Ž0b¯:Ÿg5ÿ¡Îk²šý 1[»pù`’6./'¥1R±TñâIóèÏ:mâ=[|JÙP~_8æTr—0ÿuWjJGÞ`É'TÓƒ&¾ÌÕñ²r’b³"¢ÚÆ…z
-WÑâ¸]sZaµšŠýñâ˜0B›í¥Æ‘žïXG4)¤‘‚‡ŠËÖÿQ¨¶‡¡ºÂä)Qn‹·-S=%Ö1üºüæ@Ü×ÒT©)âþX‚{Áì*/¦î¿Vz¨$
-e$Ÿ»³Z¹–×x]a2º:«.É\Ëù§„¥“*ó£WC8ux>rosÁ$Ä«)Ü®½Û)·¦7Iã<³b7ÕZ¯Að0÷“ƒ·c£ðG&"§E§#õÇƒ1Œ‚‘,Êøï£?èr¶^Ï«Ù„ýšc…sv	Y¹ºL€˜¼ÛÉ}dXÔ	ÿ>UNFó­Ž+<>¡KU¢ó¡z&ó~QN¥6^…ù<Ì¯7ã$'ý§¬úR*ôGç÷I»%Úz¾Èo¹]åI_É•ªÇËãª§ÛË»Ce–±²»‹©¯'õ§F±í$êÓý‹)³H¦zCZ 
-{T{‚¹¾ÎŸLií‹W£W~;ÿØ}}¿ÙÜßñ?íþåþ~3õ§]vo'PG¼<åŸÙø
-ä1xýDS¦¯ÿÌI{É&¿ŸÈµ‰Í(öD’K>J1õ?Ë%°c
-endstream
-endobj
-
-250 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 228 0 R
-    >>
-    /Font <<
-      /f0 210 0 R
-      /f1 216 0 R
-      /f2 222 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 3
-  /Parent 1 0 R
-  /Contents 251 0 R
->>
-endobj
-
-251 0 obj
-<<
-  /Length 2436
-  /Filter /FlateDecode
->>
-stream
-xœÕ[Ys·~Ÿ_Ñ"-ZJ¢&7E‰E;•¤¢TRdU,?PkÑRŠ\Êô¦\þ÷)Ìµh°³äîŠå—ÝÁÌàêþúDÏéWw«W—‹¼~sÖüØð"þ¹ aqÓœ.,~jƒ±ÞJgâ¥ÕN˜ ?-–MìyÓX’ àºýC\7ÝP×Í‡æªùwóÍ›³ætœõåËàô«Õêrñáý÷ðíéÅí§ïâ­óÿ½[ýòé=œþõýå÷ïïâ­‹¶ý¯Ë>./Wo—Í«Wðúë¸j#-¯8­à¦1Z´W×Ý•ñj|¥m~hþÓ,›BkïÈÅÅ§7Ø°))HMä¤Ž*ÔÒ"RE›–2šàÁô7ù€^y¨,\7äçA W@Þ UW(e¼Z4¤j¯¯Ò­nßÐ
-}¼B¤%Rð@HÔ(¼cÐÅ½S@›..€,êàÁJ$ ƒA{°…‚E$Að E@"¸n^ÔAz­½I•UÖ¡¥ <q\ãƒNxRb ¸^ŠÈð D@åãH¢—T|@@dâs"tˆ76ã~:5Þ¸nÈPœiì`*Û5UlÔnBÜ¾3í€Òht®éº¸5#1Þ÷­÷ µGgAFRÇõk¤cÿàÑ9$êˆWò,:	2Xô±% r×ŠŽ»Í‡nõq2i‘Ü4^ £HWGó²m‘Ð±_Ž¤ðµ[ï·"…@o=TlÛŒûŠö‘Ðñ†È[¤ ±³Šû#GË²h…®»óO—Ë^äÞœýíkkßI°Þ£Ðñ^+RN@)Td"øe¼'M‡ø×€‹»æôJ€pq•*7Í·ÏÞ
-!Þ
-aâÿQüøóEw[ŠþŸúÙý“í»iþÞx¿ÿ'ÇŸ÷…Ûn|)žo¾¹˜¨©L9¶4	ÎÎÞE"é(ÓNïe{/”Ñp~öÏF Ÿoz]9ˆ÷yATa1hí" ¹‰C‰Z½ª¥ûqÊ»‘¨ïúVGÊUöNO`¡8Çç*cÔ¦±‡§«tQcß«äY{Ý?V2Ù)6R;þÓ¤»v=ÌQº†*]k™vQI—þÉ°¯Uq÷W{ T²Ï5%º­ÔƒäÅç›^|»ÊQŸƒPV@¨zïÂ» ˜ò=ÛøÕO'œÌT"wÆ„ã‡z½Ã-Ù*9ƒW…79”Ü4Ù6Ò¾WÖ}W˜qh¥BtÇÖ«§­ã´ë D‡ÉúâŠË™Ÿª€,ÉÃi@*•a×ÃnuÖnYs›ÒåM¯P¨èyî`zIÕ·ÅcËTJù;h†a[£rÙvMÙÂ*“YV—˜÷]Íw×_¦µF× âÃ`™$“šã‰‰Wÿ¸\þ ÏÞ/ŸWdz»êäêzvLíÛv¢‹4Å5U¹Åq©šéÉ”¾™ª­^1Ì‘ÐV¨&-Jo%«vÔôGLD©ìdˆè1ÊÉÂMsjº›9 kÛšÍÚã² G·÷kÖ(°MzŸ¥÷³¬‰v²Å4Ùâvˆ9B¹YÌž3Œ#©‰Ç•á´8IÎ9|º
->…EC3%,ù&#3H4SdOJt+zkœëòÄ=šº½k%Î)_Àcac'$£â}²§«Q.Ž2ì©	ps¨DIEû!²«Dzr¹[M	œùˆ9²çÀçËàÓÞ¢SåF“2lp Óà¥¦ª?×W%FOôBGøA›q»k{RÂK7Û¬K*ä5]¦%%¯uÚÄ”W¼"ö4u7OÛ!JvÏáâ¿E¥‹7X^×ÙîÛ>Û«ez`¬Z6*Ó¡ªò&"IûŽÂ~þPû5ÊÖ¬]…«I¾¡¿'ÃÂ‰ª`R1ãzÀ`h/öú)‹48Ä¬wN•$„&ƒZØÇ’oUeIa]{dÉËfÇ…¬Ó]À,:Pò¡çó²h57ÄùÛ»÷r¨Ë~á½œùYèU¢u³s¡Ïˆ<SC^aYŸx3ž?gý—›\“£)ƒ·Ì1ñäÕê×á†—rqk+Æc2žóœÏ0ê ³¨³Ð·U”9Bkè¶æêv™·	õÕ†$io–•°QiÅü±€¯²¦°®=²æ½›¥™E)khÚáÜ£Ö{™9%<"IõË˜°ÕæNg9ÿÂÏ‘JV/KmÒ0/§*ëË)å^ÏgáZ‰„”Tè„|$¸Êj$TZ×ç÷”¶ÇÂLj³öÚåT!?q)I7i²d©b²gØZá€”OÀ{§ï—2ŒÇs}YQ6}C·ÙcÊj|¤„Â æŒûãŒyÇˆ?»úJ€‹X‚y,©­Æ7…eí×üï=Ê/œê3ý½½toŠŽW§ÊÃ²-NˆÓ3«{¸ÝLó35kYd%’Æ`pú±0Z„JëÚ#HÿÄy™€ódÃq8wš“±)…ú 7cêTõ3Œ·4e_Oïxè°…J¬œ'JE‚á±çªˆ+®l˜U4•µGI©½ûÜKŒvr¬àkÞLTŽ3+G¨%UøÀ4À„¢,©”¦*–%¯lê•Ó!
-ƒÔ‚U2ÐxEæ°]“6 %/T*?DVìÁìxRƒi·)ê˜êê:¦qÓp¢×NÝöûMúÒIÚ q/¿MuS¹¬b`žöÌJZ€o±ƒùšÀoŸÍ¢!lQ‹B6 Ó;éš_w5
-Ÿ+^–ËJ3ðOŠ3á—Xoš«ÛA©¤F7S£YÞºRt5‚/S£ã{wã¨³Õ;ªRÞ~eà ?©+äA¬X[¬\ä6-÷ºýÿçõåà÷ò"?`ÈlK³RQÄ¤2U7fËBÏÜe^V½*˜Ÿ2êÍ§•Õ»”mV*×IJTÁ„]j·+^Ÿ­üÊ3!<Þây‘Ù„æ}q¸ù˜ë¸çVy8_.\Î…ç£RÈ±•ÓU8í{€«5«J–„„Œ(…ƒ¦$âÆ.§UQªR°KuÌú­1O|?KBÑd2fß_ÅZvãg^…´‰’›MÖLŠJž¤´:)DÖÛžƒ©Jº—èµ
-á_âð#KqyM¬æ¤zªþýåëÛÕêö†‚ù—ÛÛÕÜ'˜¼ uôê÷ùyT&ïùøùâ3 a¾ö¿œ…é1÷×_Sú?"z/¬ìûÝ&5ú"ávB6£4ÚQ®%²¼ÉÿGsçc
-endstream
-endobj
-
-252 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 228 0 R
-    >>
-    /Font <<
-      /f0 210 0 R
-      /f1 222 0 R
-      /f2 216 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 4
-  /Parent 1 0 R
-  /Contents 253 0 R
->>
-endobj
-
-253 0 obj
-<<
-  /Length 2125
-  /Filter /FlateDecode
->>
-stream
-xœí[ëo·ÿÎ¿bj7£õˆ3|·®[IÑuÑ@ôC”ÒE»NÎåŠ¢ÿ}Á}œÈ]òöN:ù‚F_vÉÝ%w¿ÎpvOÞ¬Öó5¼}w*~$¼Œ'æ7âd.aþ“t,HÆzËÎÄ¦ÕNš ?Í—"Ž¼–$\7ç8Åµh§ºïÅB|#¾~w*N6o}õJ œ¼Y¯/æï¯¾‡oOf·¿‹—Îþ}¹þïÇ+8ùóÕÅ÷W«xiÖôÿqñÃ‡åÅúÃíR¼~o¿ŠT¶h¼Rà´‚a´lZ×m‹ClmiºïÅ?ÅRü($J­½#‹œ§²iSQMäH¤V*ÔÈ"JE›FMðàz‚A> W•…kAÞap$zäZåAy…Ì±5¤jÛ×‚´A«›'´B[¨4#„da.X£ôŒAy§€&v]$€,êàÁ2Á =X‡RÁ<Š x`®ÅK‰:°×Ú30iTVY„–‚ô€ã¼Æ;ôÀÌ(ÒK”¨|$€={Pñ‘AŠ÷‰Ð rhÜ¦ùèÔæÂµ CñM›F¡²mWÅ®AIíì&Döi&d£Ñi¸ìºÈšaŒ×=£õX{t8Š:Ò¯5’ŽãƒGç<T¨#^94ä!Xt,úØ“Hµke«]†¹xßR_ÆÉÁðE¹Ú8›ç¦GRÇ^|8ŠÂkÔ>²ÞÝ*²ÂR¢·ˆÛt#_‘a/(é¼E
-«È¹8Û€yctÙ}¼Xv&÷îô/_¼3¡á;Ûò^+RND–*0™ˆ~Ž×Ø´;f+q²@
-f‹Ô›H˜Ýˆo¿<—Rºx8—Ò¶gŽmy.©ïswnúÏJw~ÓM£»‹Tž¶}¸ŽÓŽj:ËîõmO*›÷ïÎ/¾ƒÙ_Å×³š4)¶þv±ü¾¼Z¾¨ˆÖªí÷•,q]²çRöRèí¨Ï?—ÒäÒÚ(¥½™]m{ëÁHW^úä2¹²hŽ«)	rEh*BYß_j¼Uj¿ÊZÜ±p2¡Édy™ò¯ôN“ŸOM¶Lv™ÝI…X íN•í«7Ö±È`¼ÎÕß?Û©½Ÿ]§#e:r5 :›5aúYz½·dr™)vw¹›‹õ Ÿò-UþÆž«fÌ)i–RntÕYÿz
-yª‚<²¨‚,ä=Ë]ÌF£\Ðúˆ¥ûº¨÷Tz«’Dæ<@Q7ër?Ít“B2êE<~6†Yb #'&µ³ýòÐƒuš•îÉUöŽò,›ó@YccŸ‚š.CÍ‹–ù± 6fl³dÖß=•:ïáˆ\Ë¼Õb¬ÿ´Ênª?§kIæ&?ÏéÜ¨(·”üjL0¥>SQŸ(u3Y§MŒ­c+jRÇV’#Lë®S»0û×¢l(o°LÖQå¾L&¡Hi¥,®n­f“IB<¸@‘EÏ‹Èh5ÐÍãwñðûý·™MßQ²ž¶¿ñê{o/:…|W™Èî=×äŠ“Ç¦—‰.ó(éùÈ1å.ëÎãd¨éç*CjyˆØgJø¾âvØ }$·ªˆ(u@H¼JõÐ+GM›L1"èÕ8±õya%ãBD±JÞ–‡îY¬:íS~FÁŸ®›bœo2G®l9I¨È	ÇDU è: ÿI1[8Ü²üUsþa®_\+£—ƒ…:w)&R”çÔ×ÜÜx2!®Xñ6ûj¼”~1–Üëþþ$\+;Ú9TšWUƒk‰®Oéw÷ÅÂÉ{:‡Øfà-V–eY UsÇ&c-v/J£÷
-^ŠcÓ¸º—leó`øº
-1ãÐØGË(6üåŠ¹Ì„?I}%IÓªÙ`?’ÕV“´Y‡Ÿžä´¸Ëð6¦­{Ûg‚àçÕWÓªv.òÝÐqN0W¬qð TÓ+‹«@T´±uŒú*Ft¤Ìu9Ø|ËÖóÝ7’%ckÎ¶˜1ªº7‹rZ^X[F¹„+£1Ãî.±”«9ÕÕžƒ7–5¼•è: ÞdIeÏQrh9*?EMä>[ÓåDb{š¹‹Üâ¸','—¨G0‹äƒˆl²‚H˜Fcõc•´}ª¾¾Z—X{MÙ4ßjýæD_ÎTÇå@Æ-ƒÿ6ôCKàÌ;ÔÀ+TÞÿòŠà“Ò«T!9Ä/?ø“×¿i´ÎT<PjýYß=ß›ïÎµ¥ÆÛ¼Ô!<ëž¡é*ã ß\îRõ*ìõçÝƒÞ=‰³J	’E©/µÛ¿B;%†ÎäÆËíƒ«¸;à½ü¥F²7’®cÃb~iwUÝƒX×ž^ÏU÷éON¦³¯»Ñ¹¦AVÉÁÙX|È·e“Énîšs9¦¦2Ûöå‡Ë´ß6L²o+ì³Gëµ<ÖÞ!W«xeÊ],>âšòTW¾g]yëÕ]–ƒô‡©Ñ~ò}Á±åxj—è$k“Š©$ýä5u,¤ªI‰®§jÛ/¦Ú¦*É;ÙæŸ“cÁ•«p-ÐõTmk¥úTmÛçëãjA—4áã}~pb›ªd“ñŸHà±ö–•©
-µHÙSÉíÿ¼ä¦*)Yhþ¹‹ÿÂ§ÕŒ¬HØSÑíç[t«ÿÖúöv½¾½ÉÿlýÓíízêÏÖü9Ôqï~SÅ8=ýžÞIã=7ÍØPFÃÙéß…DÿÞuèö?•ž‰oFyzˆ%„m™ZI–ë±n~ÇšcÿòÙØstiïÊ_¡]Õ0M¤ò¾L´ˆÍ(ö‘$×îMæ?þ1q5
-endstream
-endobj
-
-254 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 228 0 R
-    >>
-    /Font <<
-      /f0 216 0 R
-      /f1 210 0 R
-      /f2 222 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 5
-  /Parent 1 0 R
-  /Contents 255 0 R
->>
-endobj
-
-255 0 obj
-<<
-  /Length 2254
-  /Filter /FlateDecode
->>
-stream
-xœí[ëã¶ÿ®¿bº{Ï¤7Ëá›í!Ev/E[ô‚k rù°ç¬sWx½ÇEÑÿ¾Y”Iš²´çP _,‘’ÈáÌo†ó Ï¾^o>.®æ8{ÑüÒðŠ/.H˜ß4gsó_AAÁ‚À`¬·Ò¾µÚ	à×ùªá/oK,Û+±l¶C-›Í¢ù¾ùæíEsÖÏúúupöõfs5ÿpýüp6»ýô#w]þëýæ?Ÿ®áì/×W?]¯¹kÖ¶¿»úùãêjóñvÕ|õœ¿aª´h¼Rà´‚›ÆhÑÞ-·w2ð]ÿJÛüÐü£Y5¿4…ÖÞ‘ã…ñÊÓŽlØ”$ƒ&rÒ–+Ôò‚¹¢MËMðàz‚›†|@¯<HT–y‡Áyè7h•äJÉwó†´Cmù~Ù6huû†Vèù5–HÁ!Y˜7R£ðŒAÇk§€†›Ž	 ‹:x°	È`Ð¬C¡`Î,¤HËæ•@¤×ÚK¤QYe-Z
-ÂS Éãï<tÂƒ”1½ÄÈð D@å™ ’è¥Åˆ?'Bg€È¡q}“×Ð©¾cÙ!ž©ÿÀ(TvÛTÜ4(h;º	¼|gÚ¥Ñè4,é:^š‘Èý^¢õ¤öè,Hf5Ó¯5’æïƒGç<P¨¯24ä!Xtd°è¹%€¥kÅVºæÍ‡-õ<™´Hn/ÐóÕòh^¶-š[ü2³ÂkÔž—Þ=Š—"…@o=TlÛäuñ‚=3š;”ð@Þ"à¯V2o•®S»ËOW«NåÞ^üõˆ
-õŠï$Ø ÐJAÞ:m'|çµ"Íw	ÞÏg€Ùº9[ 	³EjJÌnšï„ï„t/aöÏæ›ÙQT!Ê¬“EL‹r
-J¡‚$ÃJ)¹Oš©”ýÐ’&Zú[*…n¯«ö÷}×§²gÝ›Ê¶×Mö¦Nú„j['ýOì§í—‚\Ç‘>•ÝlRm“-sÚ¤Ì¯”Óü>ÿJ¯Rˆ|¾Ø«+«ßŽ#„Kø3i­GM:óIòh•üFAÙ—?Âìoð$@®Zû 4H1Œ¦wBPw-D”A+
-(_“.FH™œ­gg{ûæ—ù0[ä@&œîÍd„8§K?–i£&—{¯ÝµÇƒÁ"P&ÁÅe#Ð÷ÖÅ;a¼—í-ß(£áòâÛF 7ÞvGÜ#/‡   @„Òó>$ƒ2
-¨[»~;Án¬w xº¯hÓÌÆAu\”C­Z„U¦ÏÅ:;{³Øá0~L|šqf‘RÕ¾FcÍÕ)Ííde…Ïò%Q!ª1ë£ëà3ì|')Ù‘‰j²)ßõê
-³Eÿz@þ¶Þß¡öÓß¥¯<¯p>}9"×åp.^y„ýUF€æbïaÞ)¬=çŸ‹l´bWÞ®*Ñ“‰P3Ps„N™ãAíiæ>˜lIj×:I¬zù>IlZÏåÈ‰^ÙÌ Çµ³­Ær³Q¢8Š)5*å§£žÞúåÎ{O« hç1÷ôÃ&X¶èEÓ®¦aÉ`ÉsÃ,ÝÙbñ9Æj>SÕ¸g›G¦ÚUªqOUiÆ2GuÔ	^§ ¾[8ð,ÃadJÕêõ,Kw´öÙ›ªRå ©pñafthn hJ"yuL¬M3í0¶ ?° ¡ÛÁç‰¡ÃP]#ë¹úzÔë(4û°«;â‰FÖ¢Ù><LG2Í7¶2»Ý)ãoáoa8Ú´J~®Î`§F×ãîôèï¦ô]ªÛOá“Ô@>NÓ Ÿîg§ƒ”•ÎÏè"wfz-¦ÇûŸíE Jbz _£EkìçÂ´Ät…®GÅt´{6²ŒI«áy]Ð#é¸"-Ñù?#š[à\²×÷ò•¹çºóZûNvºâ­¹Ç±±¼V\Nø\p4ƒpÜ'ë8G>Íþ?	n'…
-OF±naEƒ8Zíe?¶*
-Bæùi ”PÞ ’þèYÞ47ùÀzÈÝœÊ;Õ~v™—í0ª¥§<Óâ"Ç1ç{‚¬=rÓ~(£2:g‰œU¶¢$õÔM7ÑÑ@H§”iÐG«Eï5Öfb„Z¯ÍÄ%BRòé`T&XwBŠýQHËjP|OÚ;”u”t)ŸŽUÖ¡ZÛê5Êð Â©a1…T³-æÜ"ûúJænwË¾ø²R˜Ë¿Ù‰´×öºåØ‰x¤€‡c¼ô‹ç©ömáÙ~÷EÛób2(HÍçøLÌÝ€‘B"†„|û÷«ÕÏðâzõ²†ÒtÜ!t@‘×÷“X5ÑvfEÝÖ%ò™Ùlûÿpõ’óhùœÔŒ<JB8ÚÆúrJþed#V¾©ÅÕŠ|¶Ñä‘±9”¢­Æ0±UÐ6c×\é)îñImÔgu2'W8î‘äÅÙ@ÜOÁ£¶êˆ8+Š)•Rsîftl{v Ü^OóïS]L>yá-I¾L)\×f~¼„Ù°Ø­)«çŠšêAëƒÿî"«G7p>„œGëÝñ€÷ ºéCóÖE,¯d” sIŸ4µ>½^  úîÕs1ÏÂ}§-Ò&Ÿ©‡ §ÅKµœÛEEß@z‰ŒÇ@tD³wxó’äÀq’†::–~Æ?,"¤˜¸.Bà½øgÄ9~u×Óm{\±£¨äÅÖ>H´r¬¶ƒ‰èjºÌ°ÖLp¡{`Tâ’ÃE¤Ù+¡ÉœˆHÕìK¹Ýí—Ë·Ø8c¶uô[iœ)]ãb
-ÅlÑ®ÅÞr½e"›ŠÈÏsO°<Õ”ÏZ—Å€„„¥› JgÑ{sLPîeˆ&° ºõÅ9½½c¬D¢·RjË²õ`Üº÷w”óÛÍæö&ÿGÊŸoo7cÿHÉ fkó˜]›Ë{…çsÜ³ÆPõšS‡ë'EdÏK|šî‰è¶¶)êf=}Xu8÷*P¿O	-cÁW‰´¶¥Ñ‰s-ã¾Èj8ÿÚ4J(
-endstream
-endobj
-
-256 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 228 0 R
-    >>
-    /Font <<
-      /f0 216 0 R
-      /f1 210 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 6
-  /Parent 1 0 R
-  /Contents 257 0 R
->>
-endobj
-
-257 0 obj
-<<
-  /Length 2114
-  /Filter /FlateDecode
->>
-stream
-xœí[ÝoÇß¿b ÅIÔ£ÙïÖË)Ú ˆ@â<HŒY»(GaPô¿/–¼;î.wïh‰ŒŠV/¼ÝãÝÞ|üfv>îÎ¾¾[}X\ÎWðêÍ¹øEHð"\`˜ßˆ³¹„ù¯BbÐAR° 1ë-;‡V;iü:_Šxç°Ä áz}ŒK\‹ÍR×â½XˆÄ7oÎÅÙðÔ—/ÀÙ×«Õåüý»ŸáÇ³ÙíÇŸâ©‹ß®VÿþøÎþúîòçwwñÔl=ÿþò–—«·KñÕWðêu¤Ú°Eã•§Ü£åzt½qˆ£á’õô½ø»XŠ_„D©µwä"c‘óôD¶l*
-â ‰œ‰´‘
-­e¥¢ÍZMðàz‚A> W•…kAÞap$zäZåAy…Ìq4¤jÇ×‚´A«×Wh…>ŽPiF
-ÉÂ\°Fé=ƒ.òNMœºH YÔÁƒe$ ƒA{°¥‚yAðÀ2 \‹u`¯µg`Ò¨¬²-é) Çuw:é™1P¤—"2<(PùH 1zö âD)þO„Î ‘Cã†iä7 SÃ‰kA†â“†ŒBe7S§%mV7!²ïÌzA6†kÁ. ‹¬ÆxÞ3ZïµGg£¨#ýZ#éxðèœ’
-uÄ+‡€†<‹ŽƒEg	¢v­Üh—a.Þo¨c‹äàFx‰Ž¢\m\ÍózFRÇY¼8ŠÂkÔ>²ÞýTd…¥Do=+v=|E†}t<¡¤ò)@¼YEþÈÅÕ
-Bæk£ëÌîâãå²3¹7ç{rkBƒá;ZÖ9ä½V¤œ‰,U`2ýÏ±Ù@þÕLH˜Ý‰³…b˜-Ro"av#~üò­”òíóø«×C)Ýúxµ™)•Ì–Ý›sRÚõqÕÍLwäâ*]üŸß½=Ÿ=wXÅ$Ï¸ÊWTëkN6ê–U›e)iJg³ôŠ~Ö³ËÙËÊ•«TÝu˜Nv]—UþÐ\r'éÊŸWØè×ZT˜Ë%”‘ÚÉ·£îùO0ûV|3k‘@tgw, J¦:Jzõ2gÒÕ	O½Jª8ûbW<§cèË;:Íå¹Å±J)=-.Êþì–QÏvü,ÕuÇowÛ6È+Xª2s×†éçUÒs$ç¢+:Ê}Æ$î¸;£Q:>"îRÑ¤xÊ¥»ÜåzðF©U.rTåš*<Þ á¹™K|½ÎÎ™ˆ«œFNfNJáÍºGæ¨ºõ…GÏdv5¶+À,T£(›ÁÂ:mbüG!:Ž’8p=$Üs˜ýs„(]!Ê¬“u@´þ9ÃÀÿçþõ¸»ÅœŒ8ÖûíÈ¦‰6¹‡åïR‘žl5<µGMñcë&mbä­õ#™´k	¹FÖ¥ü2EËi¾e&ZÈ¶¬nÌ5k/ÝnãJêÍ¨Û XfF×—.æÙöÅ#žHæ>kKEs3k=3f'7YŒì·W©l{¿—ØöÈ½'½™œK‚§`ï›³G³ãEU/W™ì§ˆ›UCQœúýl–dS¤º5ª~ÿ±	¶Šˆk-áý#¢ÕÞ²mëÙ6SOqÚ|Ô°›îKu™=¥fµW4Z±ÆâB©ôdæÚH]ÅòÔcÅŠÄMVè:(H{o¾ãíÇ²Ò†‚Çw†²ÄÓE£?ŸoõPVWÓWRÛííÎ¨‘Vè@(+¡fZQ!ë€@‘ÍBCÝäkž¨¾$š(³Ï~ëC¤'³¡f":‰Ó@‹qì˜€Ô˜K­¬æa`µ61¦­ÔZóì¨WO¯€mŽeÛ‚Ü‡;¨PŠ­¯<œ¯£¤²»ŸÓIÊkA#Ô¤>ˆf.Ï÷ê,]Ú†©¢d·W•|µN¦*ðYÞZTµxÇIxò	¨#…"céwÝ“=ÄÓ,“ZÇ$ì\v2 Œ}¯ß¥Ä¹ÍT%3ËÓ®²PYþ›E=~s÷hµpu«vSF®¶”Õ~Å­¢4ý‰…Þ2EÍ‘V©4ò51Çg‰ù¶–' Ó¸«ežŽAù€¬Ž—wÖ¤<’›dM½²÷°ýg…>v|Â³rÙ<¥P£-ŸåDÌú@5}ø­ ¯qåÊ«vcéM×I$6ÊÊÔöxézîù23i¡µšOÑöœU®ÌFs¤(3õ ÉiË“ëª¿ÝyîènVè9O¸jÙ`³]_-±É¢R¦ïß­šl6^œP:Ä4íˆÁ\Ñ¥+Z­©3Ù#™‹ÈÊ>sÞÛhÄkõu³³Yñ~ßàì~]<n”fs|ÕéqòmnVf*d;þØ[@µü¬]É.jqªèß…øS¡^ýcüùSÍQlÄöE5Ìì"©“]&O«;AJF-|@óŽUd’Q©c†ýŸÔ#ÍÖªål3Ù
->Ûç=–ÿ¢×joñUCçQÜcù¨fó·NÙSgr#×§Îä't&Ù6Af<OÇÙAš“Ü(¬°Òh¥•ÕŸäfË·NÙS‡ò¼CÉü—I¢U„RÕì¢WÈzêO¤?9†»2–ÝIðx¼d1Öþ7O9&ßß¤º(Hôæˆñï}Ka“,5^U&kÑ;Âcr3Õ¨SöÔB>^~ÑþªîÕíju{“X÷—ÛÛÕÔ‡uÙ-ulŒÆs~!$ú_ÞIã=¯‡q Œ†‹óï„DÿÞtöß´]ˆJ,{äãGi÷„r˜~1eŸRß!Þ£Ôÿ¶o#¢Úÿ‡”Ð²Qý"Ñv"6ƒº#I®÷&óÿÈlÔ
-endstream
-endobj
-
-258 0 obj
-<<
-  /Type /Annot
-  /Subtype /Link
-  /Rect [270 275.164 450 294.94]
-  /Border [0 0 0]
-  /A <<
-    /Type /Action
-    /S /URI
-    /URI (mailto:michelle\\@cloudnativegeo.org)
-  >>
-  /F 4
-  /StructParent 7
-  /Contents (Email michelle\\@cloudnativegeo.org)
->>
-endobj
-
-259 0 obj
-<<
-  /Type /Page
-  /Resources <<
-    /ProcSet [/PDF /Text /ImageC /ImageB]
-    /ColorSpace <<
-      /c0 228 0 R
-    >>
-    /Font <<
-      /f0 210 0 R
-      /f1 216 0 R
-      /f2 222 0 R
-    >>
-  >>
-  /MediaBox [0 0 612 792]
-  /StructParents 8
-  /Tabs /S
-  /Parent 1 0 R
-  /Contents 260 0 R
-  /Annots [258 0 R]
->>
-endobj
-
-260 0 obj
-<<
-  /Length 2469
-  /Filter /FlateDecode
->>
-stream
-xœÅ[ÝsÜ¶ç_K©5õ
-‹oÌ8îDŠÝ¤SwÚ‘fúåAºH±;ÒÉQ.ÓéßàaÁ%yªÄöåH €Ýýí'pÇß<l>Ý\®6âäÃióKƒB
-)^§‹J¬îšã•«_	ÑD‰Ñ		Ñºà”·éÖ/m¿®ÖMúò®q¨„·í5qÛl‡ºm>67Íß›wN›ã~Ö7o!Ž¿Ùl.W¯?Ÿßþ1=:ûíjóïÏ×âø»ëËŸ®Ò£ó¶ý·ËŸ?­/7Ÿî×ÍÛ·âäÛ´j«Ø µðF‹»ÆÙÞÝnïTLw}—¶ù±ùG³n~i$Hc‚GŸK”—È°%+PEƒè½€[®`Ë‹Äc[f¨ˆ`cÁB@q×`ˆt
-´·Ñ!!hÁ‚ÓAHAƒRénÕ ñ`\º¿mÐXp¦ía4„tF Q€1tbÕ(2a-øD;F°©éÓÐ‰A8(ÐB4A8R‹UbABÉˆâ¶y-ÁDŒ	J(4 vN 8Œ2`*kƒÂ‚—A(¥ bZ/&d¡eÒPAPAèô¢LïÁ[èÁú¾™èàuÿà¶A‹i¦þ«A»mS§¦‰ÛÑmLä{Û¨¬oÄm£|ŸH³
-Òó À… ”	àP‰ÕiýÆ šô}à}(5˜„W#X":ðJ¨è ¤–IºNn¥«Äªù¸]}šL9@/îš Ácâ«K£Õ¶PšÔJ+‚éÝë¨)JJ.T¢k›‰®DpHŒN´ƒŒ"}¬}èÓhÕBV­ÒujwöùrÝ©Ü‡Óï¿r§B½â{%\ E|0µ×B‚’:*´	ü*=Sv‹ø“óFŠó‡æøF
-%ÅùMiL¤8¿k~øòBJÒÏ…T˜®_mÒtÓ½¼èºçÝ=}ŸŸKO¿—í Rªîª«÷–ýþªýÝý(ÎÿÜ¼;X©Ê6¶,’‹NÏ	Á'™¤Ò^ÚT{›n´5âìô¯+þÕñ¡3•Y»ÏÆäƒ#ò±œ{‚€P ÐŽýÛ7¥ä
-ææÞ][©¢÷a|7‚ÎbØŽCÆ¹)z®™~yMfmç9è^•ídM—Qô»/&&®°Õ‘Û_‘bîjGÈKfkB§£‹ë¦Z3°œ©\ãIàI[!,†§,ˆ–ªCStàå%•+ÙF@’ûÜ°2ÝIÊï?~?F]í!¨Bâ=ÓÈ¤Ê‘¿ÀmýŽÂ&ãqûö ÿ¡hÌK)´‰Jì	°Ó#°Cˆj93Ös’ªW9„ÅY‘·+µ8¿j[ö1ÖªrHë¡^PÀÂê‡Ø~ú°{vHFÉDf¢	³£g î=¢ˆŽ<TèåÌ>GZzªKÔQPýîçŸCšá‘f£­ÝrHëÖYq­£¬ÒÃžîIû“mWß&v¯Äáˆ”&-Ùa)ºß±Ò1d&NždŠEJÄÕP¤…«72¾LÕ&V³‚;å}æáÚà‚ül“çgGçØå GÝgGØAeïA-á!Ë€Â¸±Æc$¦Þì–pµ3³dö>z×åõp÷aFwÔö6œÈàüˆjµ&T#¶ørå`ŽÕOpÙ>}7T’‚Âbù/‡#ú¡Õ­(C™A™uàÃâ‰À§Z¯8Ž•âÍŠåƒbV¦¼ÍìÌnzÂˆ•ƒ¾(Ç|YU¥1«Ot®d8f­%ºQY#2Ü1UwµpéÇ€¡Wì³`ô#`Ô¤\.‹š&÷•¯éØK3©2±hßÈŠd5bqvar5OÛåm5uéý	Ã;á”ñ¡ì¹b†ý=ú›ù.tÕü
-jMY~bUû¬ð'äE©#ËÜÛ†¢¥—Ì(ªêÙ¢õtÚ•ÍBæe5]ZÎå$\5f±
-M™ìâF.^¬Lâþ\*5šƒaäah¢³`ôGÒ©ªÈ±3Jzàãë´Ÿ=q¯f`Ùs”„8ÔD¿'`ï‹sÐÏ†`œûý#§c"PXúAð—Q…U0Ê¸Ö¾ž4-NUŒFÕ£°ò³0Ã‘:½ñ\øÿÔO˜ªïOMI)šYÇÔsI¶É ZÆÉè5¬T:Ï'f…1R”7V>e×d¶Æ°ïÞõèãÎ´›: /éªzWåÎK©…3óõ+®¶1‹ÞyVn¹³W%’=bÃY`ŽT÷– Õrf¢JË˜È›-1f\Ø~ö[XÎÕÕ.„ÈÓ=ÿn³ÃÁÕÅ&ŠiÔ©p°ÍÄP×[z¼™ ²áÍ<ºFŠø&m¿ÛåBn^]ÆÌ	[Œ¤#uT®ÎÂmª˜±W•¬ŠÈ$E>±«÷Ò:Àc‚âÇíh™±ìm&«™ÞËªí#©yÏûØ‘:¾vé¬‡ZêdBa('ëjxï2+Ž×ÕÇZâ#Nh«J;Z0R¸Ö*€JÇ‰–Ñçìž&oá‚h}‚5‰ÏÐ<êpÃ £Ü3&›Ö6&ªœ(;zV… >.ÙL~SÅÒ½õ®”Úe¬ÃÛ7v)pkÀ,S o=¾Ÿþ~–Ÿnÿr¹þY|y½>âéR!ñzÒ«)ÂÞT±Lo‡J(½NÖ‰-ý_W.§æ«YÂ¹¢ZîéäÎÉ±ôx_3fƒÖJêt‘Më§ŒÉw{¢š«)/y~ÌŸ)}?èþ0s¦.p_v­òú*ÙEƒX¤“˜
-œ`“½ÙCKr…B•ñ¿Ç˜zä¡¸Aí9Þ×'óNY¿g_EgýŽ„™…>çvÆÇ¬¢˜í˜b˜œ6j}¹ƒ†•u´%d2s¨¦e2eû°zXéžÓ8µûôÒ¥ÊzÑµÔ'qF˜3#ˆ‡Y¸â>pÅt´Y-Öÿ1g'¥¼5	RwRJ»ôçÅ`[Öòál™™‚boâjézÝTM.^M‚,£PŠ–id‹è¨ìóû’ôlò¾·/ŽAo™ô‡þ'¿> u!?Aµ#‚÷n)¾&¢*ùVf®¤\ßƒ«ŽK3Û†cÕ9(ÝÍÝ™±q)ÖÅ«:G {ö»<¯>£I¬9”rf‚þjy}ªÏoJïÌugÊ©Ù.yýÕé	Næ"TÖR^2?¨o»Ù—z\úÅ¬âˆ˜f+³ævCÜ\Áø¿šNî7›û;úÇ¦÷÷÷›¹?6‘Ím	FJ©žó_•W
-1¤?pÞØô¡t—§JãÞg‰øÐòj	&ãË‹g=¨ÓÖÙ\>ò]H»`›ÕÜBœk§ŽÄù?{ýæó‹
-endstream
-endobj
-
-261 0 obj
-<<
-  /Creator (Typst 0.14.2)
-  /ModDate (D:20260507172023Z)
-  /CreationDate (D:20260507172023Z)
->>
-endobj
-
-262 0 obj
-<<
-  /Length 996
-  /Type /Metadata
-  /Subtype /XML
->>
-stream
-<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-05-07T17:20:23+00:00</xmp:ModifyDate><xmp:CreateDate>2026-05-07T17:20:23+00:00</xmp:CreateDate><xmpTPg:NPages>7</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>PFPeEr9mn0q9lUt3pJah4Q==</xmpMM:InstanceID><xmpMM:DocumentID>PFPeEr9mn0q9lUt3pJah4Q==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
-endstream
-endobj
-
-263 0 obj
-<<
-  /Type /Catalog
-  /Pages 1 0 R
-  /Metadata 262 0 R
-  /Lang (en)
-  /StructTreeRoot 18 0 R
-  /MarkInfo <<
-    /Marked true
-    /Suspects false
-  >>
-  /ViewerPreferences <<
-    /Direction /L2R
-  >>
-  /Outlines 2 0 R
->>
-endobj
-
 xref
-0 264
+0 322
 0000000000 65535 f
 0000000016 00000 n
-0000000130 00000 n
-0000000210 00000 n
-0000000355 00000 n
-0000000476 00000 n
-0000000590 00000 n
-0000000748 00000 n
-0000000972 00000 n
-0000001290 00000 n
-0000001493 00000 n
-0000001706 00000 n
-0000001946 00000 n
-0000002107 00000 n
-0000002350 00000 n
-0000002524 00000 n
-0000002783 00000 n
-0000002901 00000 n
-0000002995 00000 n
-0000003297 00000 n
-0000003380 00000 n
-0000003591 00000 n
-0000003882 00000 n
-0000004205 00000 n
-0000004422 00000 n
-0000004679 00000 n
-0000004866 00000 n
-0000005320 00000 n
-0000005397 00000 n
-0000005491 00000 n
-0000005568 00000 n
-0000005656 00000 n
-0000005757 00000 n
-0000005904 00000 n
-0000005996 00000 n
-0000006086 00000 n
-0000006194 00000 n
-0000006287 00000 n
-0000006392 00000 n
-0000006508 00000 n
-0000006668 00000 n
-0000006753 00000 n
-0000006844 00000 n
-0000006933 00000 n
-0000007018 00000 n
-0000007112 00000 n
-0000007201 00000 n
-0000007286 00000 n
-0000007377 00000 n
-0000007466 00000 n
-0000007551 00000 n
-0000007645 00000 n
-0000007734 00000 n
-0000007819 00000 n
-0000007913 00000 n
-0000008002 00000 n
-0000008101 00000 n
-0000008373 00000 n
-0000008533 00000 n
-0000008618 00000 n
-0000008709 00000 n
-0000008798 00000 n
-0000008883 00000 n
-0000008974 00000 n
-0000009063 00000 n
-0000009148 00000 n
-0000009239 00000 n
-0000009327 00000 n
-0000009412 00000 n
-0000009504 00000 n
-0000009592 00000 n
-0000009677 00000 n
-0000009769 00000 n
-0000009857 00000 n
-0000009947 00000 n
-0000010024 00000 n
-0000010115 00000 n
-0000010287 00000 n
-0000010383 00000 n
-0000010464 00000 n
-0000010542 00000 n
-0000010814 00000 n
-0000010906 00000 n
-0000011162 00000 n
-0000011279 00000 n
-0000011366 00000 n
-0000011519 00000 n
-0000011604 00000 n
-0000011698 00000 n
-0000011787 00000 n
-0000011872 00000 n
-0000011963 00000 n
-0000012052 00000 n
-0000012137 00000 n
-0000012228 00000 n
-0000012317 00000 n
-0000012402 00000 n
-0000012492 00000 n
-0000012580 00000 n
-0000012674 00000 n
-0000012913 00000 n
-0000013087 00000 n
-0000013176 00000 n
-0000013268 00000 n
-0000013358 00000 n
-0000013447 00000 n
+0000000133 00000 n
+0000000240 00000 n
+0000000337 00000 n
+0000000437 00000 n
+0000000548 00000 n
+0000000650 00000 n
+0000000747 00000 n
+0000000877 00000 n
+0000000990 00000 n
+0000001097 00000 n
+0000001195 00000 n
+0000001306 00000 n
+0000001440 00000 n
+0000001563 00000 n
+0000001664 00000 n
+0000001744 00000 n
+0000001870 00000 n
+0000001938 00000 n
+0000002220 00000 n
+0000002273 00000 n
+0000002459 00000 n
+0000002715 00000 n
+0000003026 00000 n
+0000003300 00000 n
+0000003606 00000 n
+0000003952 00000 n
+0000004002 00000 n
+0000004212 00000 n
+0000004317 00000 n
+0000004428 00000 n
+0000004499 00000 n
+0000004570 00000 n
+0000004670 00000 n
+0000004738 00000 n
+0000004851 00000 n
+0000004924 00000 n
+0000005016 00000 n
+0000005092 00000 n
+0000005164 00000 n
+0000005225 00000 n
+0000005294 00000 n
+0000005366 00000 n
+0000005444 00000 n
+0000005512 00000 n
+0000005581 00000 n
+0000005653 00000 n
+0000005737 00000 n
+0000005805 00000 n
+0000005874 00000 n
+0000005946 00000 n
+0000006027 00000 n
+0000006095 00000 n
+0000006206 00000 n
+0000006299 00000 n
+0000006370 00000 n
+0000006477 00000 n
+0000006544 00000 n
+0000006605 00000 n
+0000006676 00000 n
+0000006744 00000 n
+0000006818 00000 n
+0000006886 00000 n
+0000006955 00000 n
+0000007026 00000 n
+0000007094 00000 n
+0000007163 00000 n
+0000007237 00000 n
+0000007305 00000 n
+0000007374 00000 n
+0000007445 00000 n
+0000007513 00000 n
+0000007582 00000 n
+0000007656 00000 n
+0000007724 00000 n
+0000007793 00000 n
+0000007864 00000 n
+0000007932 00000 n
+0000008001 00000 n
+0000008072 00000 n
+0000008140 00000 n
+0000008209 00000 n
+0000008280 00000 n
+0000008348 00000 n
+0000008494 00000 n
+0000008602 00000 n
+0000008670 00000 n
+0000008731 00000 n
+0000008808 00000 n
+0000008906 00000 n
+0000008973 00000 n
+0000009034 00000 n
+0000009105 00000 n
+0000009173 00000 n
+0000009245 00000 n
+0000009314 00000 n
+0000009382 00000 n
+0000009452 00000 n
+0000009521 00000 n
+0000009591 00000 n
+0000009664 00000 n
+0000009735 00000 n
+0000009806 00000 n
+0000009882 00000 n
+0000009954 00000 n
+0000010025 00000 n
+0000010098 00000 n
+0000010170 00000 n
+0000010241 00000 n
+0000010314 00000 n
+0000010386 00000 n
+0000010457 00000 n
+0000010530 00000 n
+0000010602 00000 n
+0000010747 00000 n
+0000010853 00000 n
+0000010923 00000 n
+0000010986 00000 n
+0000011061 00000 n
+0000011132 00000 n
+0000011208 00000 n
+0000011280 00000 n
+0000011351 00000 n
+0000011424 00000 n
+0000011496 00000 n
+0000011567 00000 n
+0000011643 00000 n
+0000011715 00000 n
+0000011786 00000 n
+0000011859 00000 n
+0000011931 00000 n
+0000012002 00000 n
+0000012075 00000 n
+0000012147 00000 n
+0000012217 00000 n
+0000012289 00000 n
+0000012361 00000 n
+0000012500 00000 n
+0000012608 00000 n
+0000012677 00000 n
+0000012740 00000 n
+0000012818 00000 n
+0000012889 00000 n
+0000012962 00000 n
+0000013034 00000 n
+0000013105 00000 n
+0000013178 00000 n
+0000013250 00000 n
+0000013321 00000 n
+0000013397 00000 n
+0000013469 00000 n
 0000013540 00000 n
-0000013631 00000 n
-0000013720 00000 n
-0000013813 00000 n
+0000013613 00000 n
+0000013685 00000 n
+0000013756 00000 n
+0000013832 00000 n
 0000013904 00000 n
-0000013993 00000 n
-0000014089 00000 n
-0000014180 00000 n
-0000014269 00000 n
-0000014362 00000 n
-0000014453 00000 n
-0000014542 00000 n
-0000014638 00000 n
-0000014729 00000 n
-0000014823 00000 n
-0000014902 00000 n
-0000014992 00000 n
-0000015221 00000 n
-0000015403 00000 n
-0000015492 00000 n
-0000015585 00000 n
-0000015676 00000 n
-0000015765 00000 n
-0000015858 00000 n
-0000015949 00000 n
-0000016038 00000 n
-0000016131 00000 n
-0000016222 00000 n
-0000016311 00000 n
-0000016407 00000 n
-0000016498 00000 n
-0000016587 00000 n
-0000016680 00000 n
-0000016771 00000 n
-0000016860 00000 n
-0000016952 00000 n
-0000017042 00000 n
-0000017131 00000 n
-0000017225 00000 n
-0000017315 00000 n
-0000017406 00000 n
-0000017485 00000 n
-0000017574 00000 n
-0000017778 00000 n
-0000017875 00000 n
-0000017954 00000 n
-0000018044 00000 n
-0000018365 00000 n
-0000018555 00000 n
-0000018644 00000 n
-0000018737 00000 n
-0000018828 00000 n
-0000018917 00000 n
-0000019010 00000 n
-0000019101 00000 n
-0000019190 00000 n
-0000019283 00000 n
-0000019374 00000 n
-0000019463 00000 n
-0000019559 00000 n
-0000019650 00000 n
-0000019739 00000 n
-0000019832 00000 n
-0000019923 00000 n
-0000020012 00000 n
-0000020108 00000 n
-0000020199 00000 n
-0000020288 00000 n
-0000020381 00000 n
-0000020472 00000 n
-0000020561 00000 n
-0000020657 00000 n
-0000020747 00000 n
-0000020838 00000 n
-0000020917 00000 n
-0000021006 00000 n
-0000021246 00000 n
-0000021337 00000 n
-0000021454 00000 n
-0000021604 00000 n
-0000021693 00000 n
-0000021797 00000 n
-0000021891 00000 n
-0000021982 00000 n
-0000022071 00000 n
-0000022178 00000 n
-0000022272 00000 n
-0000022363 00000 n
-0000022452 00000 n
-0000022553 00000 n
-0000022647 00000 n
-0000022738 00000 n
-0000022817 00000 n
-0000022911 00000 n
-0000023007 00000 n
-0000023123 00000 n
-0000023216 00000 n
-0000023353 00000 n
-0000023499 00000 n
-0000023586 00000 n
-0000023726 00000 n
-0000023819 00000 n
-0000023912 00000 n
-0000024047 00000 n
-0000024191 00000 n
-0000024363 00000 n
-0000024842 00000 n
-0000024931 00000 n
-0000025185 00000 n
-0000026727 00000 n
-0000034797 00000 n
-0000034972 00000 n
-0000035437 00000 n
-0000035527 00000 n
-0000035784 00000 n
-0000037494 00000 n
-0000046643 00000 n
-0000046817 00000 n
-0000047221 00000 n
-0000047312 00000 n
-0000047571 00000 n
-0000048917 00000 n
-0000056498 00000 n
-0000056536 00000 n
-0000056959 00000 n
-0000057001 00000 n
-0000057047 00000 n
-0000057093 00000 n
-0000057141 00000 n
-0000057183 00000 n
-0000057229 00000 n
-0000057271 00000 n
-0000057317 00000 n
-0000057363 00000 n
-0000057411 00000 n
-0000057456 00000 n
-0000057502 00000 n
-0000057544 00000 n
-0000057590 00000 n
-0000057637 00000 n
-0000057908 00000 n
-0000058221 00000 n
-0000059865 00000 n
-0000060147 00000 n
-0000062316 00000 n
-0000062616 00000 n
-0000065132 00000 n
-0000065432 00000 n
-0000067637 00000 n
-0000067937 00000 n
-0000070271 00000 n
-0000070553 00000 n
-0000072747 00000 n
-0000073020 00000 n
-0000073351 00000 n
-0000075900 00000 n
-0000076017 00000 n
-0000077103 00000 n
+0000014035 00000 n
+0000014144 00000 n
+0000014224 00000 n
+0000014319 00000 n
+0000014432 00000 n
+0000014502 00000 n
+0000014565 00000 n
+0000014643 00000 n
+0000014734 00000 n
+0000014805 00000 n
+0000014868 00000 n
+0000014940 00000 n
+0000015010 00000 n
+0000015084 00000 n
+0000015156 00000 n
+0000015226 00000 n
+0000015302 00000 n
+0000015374 00000 n
+0000015445 00000 n
+0000015518 00000 n
+0000015590 00000 n
+0000015661 00000 n
+0000015734 00000 n
+0000015806 00000 n
+0000015877 00000 n
+0000015950 00000 n
+0000016022 00000 n
+0000016153 00000 n
+0000016270 00000 n
+0000016340 00000 n
+0000016403 00000 n
+0000016484 00000 n
+0000016555 00000 n
+0000016631 00000 n
+0000016703 00000 n
+0000016774 00000 n
+0000016850 00000 n
+0000016922 00000 n
+0000016993 00000 n
+0000017066 00000 n
+0000017138 00000 n
+0000017209 00000 n
+0000017285 00000 n
+0000017357 00000 n
+0000017427 00000 n
+0000017499 00000 n
+0000017571 00000 n
+0000017702 00000 n
+0000017820 00000 n
+0000017896 00000 n
+0000017983 00000 n
+0000018057 00000 n
+0000018120 00000 n
+0000018191 00000 n
+0000018265 00000 n
+0000018352 00000 n
+0000018424 00000 n
+0000018495 00000 n
+0000018569 00000 n
+0000018653 00000 n
+0000018725 00000 n
+0000018796 00000 n
+0000018870 00000 n
+0000018954 00000 n
+0000019026 00000 n
+0000019097 00000 n
+0000019171 00000 n
+0000019255 00000 n
+0000019327 00000 n
+0000019398 00000 n
+0000019472 00000 n
+0000019556 00000 n
+0000019628 00000 n
+0000019699 00000 n
+0000019773 00000 n
+0000019854 00000 n
+0000019926 00000 n
+0000020065 00000 n
+0000020174 00000 n
+0000020257 00000 n
+0000020330 00000 n
+0000020410 00000 n
+0000020504 00000 n
+0000020591 00000 n
+0000020666 00000 n
+0000020752 00000 n
+0000020824 00000 n
+0000020898 00000 n
+0000021007 00000 n
+0000021092 00000 n
+0000021162 00000 n
+0000021225 00000 n
+0000021301 00000 n
+0000021364 00000 n
+0000021860 00000 n
+0000022078 00000 n
+0000022302 00000 n
+0000022522 00000 n
+0000022743 00000 n
+0000022780 00000 n
+0000022820 00000 n
+0000022864 00000 n
+0000022908 00000 n
+0000022954 00000 n
+0000022994 00000 n
+0000023038 00000 n
+0000023078 00000 n
+0000023122 00000 n
+0000023168 00000 n
+0000023208 00000 n
+0000023252 00000 n
+0000023296 00000 n
+0000023340 00000 n
+0000023380 00000 n
+0000023424 00000 n
+0000023469 00000 n
+0000023570 00000 n
+0000023682 00000 n
+0000023805 00000 n
+0000023928 00000 n
+0000024051 00000 n
+0000024174 00000 n
+0000024286 00000 n
+0000024398 00000 n
+0000024521 00000 n
+0000024668 00000 n
+0000025075 00000 n
+0000025291 00000 n
+0000025441 00000 n
+0000025864 00000 n
+0000026083 00000 n
+0000026232 00000 n
+0000026604 00000 n
+0000026825 00000 n
+0000026966 00000 n
+0000027084 00000 n
+0000027202 00000 n
+0000027320 00000 n
+0000027461 00000 n
+0000027579 00000 n
+0000027720 00000 n
+0000027839 00000 n
+0000027981 00000 n
+0000028063 00000 n
+0000028775 00000 n
+0000036976 00000 n
+0000037058 00000 n
+0000037830 00000 n
+0000047237 00000 n
+0000047319 00000 n
+0000047974 00000 n
+0000055924 00000 n
+0000057244 00000 n
+0000059369 00000 n
+0000061816 00000 n
+0000063985 00000 n
+0000066384 00000 n
+0000068764 00000 n
+0000071346 00000 n
+0000072468 00000 n
+0000074994 00000 n
+0000075401 00000 n
+0000075504 00000 n
+0000076577 00000 n
 trailer
-<<
-  /Size 264
-  /Root 263 0 R
-  /Info 261 0 R
-  /ID [(PFPeEr9mn0q9lUt3pJah4Q==) (PFPeEr9mn0q9lUt3pJah4Q==)]
->>
+<</Size 322/Root 321 0 R/Info 319 0 R/ID[(wtHU+wfi73t5ktiG0YqNmQ==)(wtHU+wfi73t5ktiG0YqNmQ==)]>>
 startxref
-77341
+76764
 %%EOF


### PR DESCRIPTION
Updates both sponsorship prospectus PDFs with the latest versions:

- `cng2026-sponsor.pdf` — CNG Forum 2026 prospectus: adds CNG Organizational Membership section, updates Community Partner to reflect remaining 2026 events, removes em dashes
- `cng-2026-series-sponsor.pdf` — NYC/Community Partner prospectus: same Community Partner updates with YouTube followup note for past events